### PR TITLE
z-index of 1 stops it from being above the icons

### DIFF
--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -45,7 +45,7 @@ var rtc = (function()
         'left': '0',
         'top': '37px',
         'width': '130px',
-        'z-index': '400',
+        'z-index': '1',
         'border-right': '1px solid #999',
         'border-top': '1px solid #999',
         'padding': '3px',


### PR DESCRIPTION
If you make the browser narrow with this plugin enabled you can lose the overflow of the icons.

Changing z-index to 1 means the buttons take z-index priority of the video, this isn't a perfect fix because really on a redraw/overflow event you want to bring the video down a bit.

Ultimately the cause of this bug is that the way we handle the toolbar redrawing when it's too narrow is a bit shoddy.

Any idea why you used z-index 400?  I didn't test much btw so please do so..
