### PR TITLE
Update stream stopping to account for disabled MediaStream.stop() function

### DIFF
--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -156,8 +156,17 @@ var rtc = (function() {
         padcookie.setPref("rtcEnabled", false);
         self.hangupAll();
         if (localStream) {
+          var videoTrack = localStream.getVideoTracks()[0];
+          var audioTrack = localStream.getAudioTracks()[0];
           self.setStream(self._pad.getUserId(), "");
-          localStream.stop();
+          if (videoTrack.stop === undefined) {
+            // deprecated in 2015, probably disabled by 2020
+            // https://developers.google.com/web/updates/2015/07/mediastream-deprecations
+            localStream.stop();
+          } else {
+            videoTrack.stop();
+            audioTrack.stop();
+          }
           localStream = null;
         }
       }


### PR DESCRIPTION
When you clicked the "Enable Audio/Video Chat" checkbox, it has been calling `localStream.stop()`. However this function was deprecated in 2015 and is disabled on my current browser. This change calls `.stop()` separately on the video and audio track.

It also falls back to the old style behavior in case the user has an old browser. Alternately we could skip that if we're not supporting such old browsers.