### PR TITLE
Error messages

### DIFF
--- a/static/js/getUserMediaPolyfill.js
+++ b/static/js/getUserMediaPolyfill.js
@@ -23,8 +23,33 @@
       };
     } else {
       navigator.mediaDevices.getUserMedia = function() {
+        // A missing `getUserMedia` seemingly can mean one of two things:
+        //
+        // 1) WebRTC is unsupported or disabled on this browser
+        // 2) This is an insecure connection
+        //   * This handling of insecure connections happens only on certain browsers.
+        //     It was observed in Chromium 80 and Firefox 75, but not Firefox 68. I suspect it's the new behavior.
+        //   * In other browsers, it handles insecure connections by throwing `NotAllowedError`.
+        //     We still handle this case in the calling function.
+        //   * See: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
+        //     As of this writing, this claims that the browser does *both* of these things for
+        //     insecure connections, which is of course impossible and thus confusing.
+        //
+        // We will attempt to distinguish these two cases by checking for various webrtc-related fields on
+        // `window` (inspired by github.com/muaz-khan/DetectRTC). If none of those fields exist, we assume
+        // that WebRTC is not supported on this browser.
         return new Promise(function(resolve, reject) {
-          reject("getUserMedia is not supported in this browser.");
+          if (!(window.RTCPeerConnection || window.webkitRTCPeerConnection || window.mozRTCPeerConnection || window.RTCIceGatherer)) {
+            var e = new Error("getUserMedia is not supported in this browser.");
+            // I'd use NotSupportedError but I'm afraid they'll change the spec on us again
+            e.name = 'CustomNotSupportedError';
+            reject(e);
+          } else {
+            var e = new Error("insecure connection");
+            // I'd use NotAllowedError but I'm afraid they'll change the spec on us again
+            e.name = 'CustomSecureConnectionError';
+            reject(e);
+          }
         });
       };
     }

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 "use strict";
+
 require("./adapter");
 require("./getUserMediaPolyfill");
 var padcookie = require("ep_etherpad-lite/static/js/pad_cookie").padcookie;

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 "use strict";
-
 require("./adapter");
 require("./getUserMediaPolyfill");
 var padcookie = require("ep_etherpad-lite/static/js/pad_cookie").padcookie;
@@ -22,7 +21,6 @@ var hooks = require("ep_etherpad-lite/static/js/pluginfw/hooks");
 
 var rtc = (function() {
   var isActive = false;
-  var isSupported = true;
   var pc_config = {};
   var pc_constraints = {
     optional: [
@@ -101,12 +99,48 @@ var rtc = (function() {
     show: function() {
       $("#rtcbox").css('display', 'flex');
     },
-    showNotSupported: function() {
+    showUserMediaError: function(err) { // show an error returned from getUserMedia
+      var reason
+      // For reference on standard errors returned by getUserMedia:
+      // https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
+      // However keep in mind that we add our own errors in getUserMediaPolyfill
+      switch(err.name) {
+        case "CustomNotSupportedError":
+          reason = "Sorry, your browser does not support WebRTC. (or you have it disabled in your settings).<br><br>" +
+              "To participate in this audio/video chat you have to user a browser with WebRTC support like Chrome, Firefox or Opera." +
+              '<a href="http://www.webrtc.org/" target="_new">Find out more</a>'
+          break;
+        case "CustomSecureConnectionError":
+          reason = "Sorry, you need to install SSL certificates for your Etherpad instance to use WebRTC"
+          break;
+        case "NotAllowedError":
+          // For certain (I suspect older) browsers, `NotAllowedError` indicates either an insecure connection or the user rejecting camera permissions.
+          // The error for both cases appears to be identical, so our best guess at telling them apart is to guess whether we are in a secure context.
+          // (webrtc is considered secure for https connections or on localhost)
+          if (location.protocol === "https:" || location.hostname === "localhost" || location.hostname === "127.0.0.1") {
+            reason = "Sorry, you need to give us permission to use your camera and microphone"
+          } else {
+            reason = "Sorry, you need to install SSL certificates for your Etherpad instance to use WebRTC"
+          }
+          break;
+        case "NotFoundError":
+          reason = "Sorry, we couldnt't find a suitable camera on your device. If you have a camera, make sure it set up correctly and refresh this website to retry."
+          break;
+        case "NotReadableError":
+          // `err.message` might give useful info to the user (not necessarily useful for other error messages)
+          reason = "Sorry, a hardware error occurred that prevented access to your camera and/or microphone:<br><br>" + err.message
+          break;
+        case "AbortError":
+          // `err.message` might give useful info to the user (not necessarily useful for other error messages)
+          reason = "Sorry, an error occurred (probably not hardware related) that prevented access to your camera and/or microphone:<br><br>" + err.message
+          break;
+        default:
+          // `err` as a string might give useful info to the user (not necessarily useful for other error messages)
+          reason = "Sorry, there was an unknown Error:<br><br>" + err
+      }
       $.gritter.add({
         title: "Error",
-        text: "Sorry, your browser does not support WebRTC.<br><br>" +
-              "To participate in this audio/video chat you have to user a browser with WebRTC support like Chrome, Firefox or Opera." +
-              '<a href="http://www.webrtc.org/" target="_new">Find out more</a>',
+        text: reason,
         sticky: true,
         class_name: "error"
       })
@@ -119,35 +153,29 @@ var rtc = (function() {
       $("#options-enablertc").prop("checked", true);
       if (isActive) return;
       self.show();
-      if (isSupported) {
-        padcookie.setPref("rtcEnabled", true);
-        self.getUserMedia();
-      } else {
-        self.showNotSupported();
-      }
+      padcookie.setPref("rtcEnabled", true);
+      self.getUserMedia();
       isActive = true;
     },
     deactivate: function() {
       $("#options-enablertc").prop("checked", false);
       if (!isActive) return;
       self.hide();
-      if (isSupported) {
-        padcookie.setPref("rtcEnabled", false);
-        self.hangupAll();
-        if (localStream) {
-          var videoTrack = localStream.getVideoTracks()[0];
-          var audioTrack = localStream.getAudioTracks()[0];
-          self.setStream(self._pad.getUserId(), "");
-          if (videoTrack.stop === undefined) {
-            // deprecated in 2015, probably disabled by 2020
-            // https://developers.google.com/web/updates/2015/07/mediastream-deprecations
-            localStream.stop();
-          } else {
-            videoTrack.stop();
-            audioTrack.stop();
-          }
-          localStream = null;
+      padcookie.setPref("rtcEnabled", false);
+      self.hangupAll();
+      if (localStream) {
+        var videoTrack = localStream.getVideoTracks()[0];
+        var audioTrack = localStream.getAudioTracks()[0];
+        self.setStream(self._pad.getUserId(), "");
+        if (videoTrack.stop === undefined) {
+          // deprecated in 2015, probably disabled by 2020
+          // https://developers.google.com/web/updates/2015/07/mediastream-deprecations
+          localStream.stop();
+        } else {
+          videoTrack.stop();
+          audioTrack.stop();
         }
+        localStream = null;
       }
       isActive = false;
     },
@@ -478,18 +506,7 @@ var rtc = (function() {
             }
           });
         })
-        .catch(function(err) {
-          var reason = "Sorry, we couldnt't find a suitable camera on your device. If you have a camera, make sure it set up correctly and refresh this website to retry.";
-          if(err.name !== "NotFoundError") reason = "Sorry, you need to install SSL certificates for your Etherpad instance to use WebRTC";
-
-          $.gritter.add({
-            title: "Error",
-            text: reason,
-            sticky: true,
-            class_name: "error"
-          })
-          self.hide();
-        });
+        .catch(function(err) {self.showUserMediaError(err)})
     },
     avInURL: function() {
       if (window.location.search.indexOf("av=YES") > -1) {
@@ -550,8 +567,6 @@ var rtc = (function() {
     }
   };
   var webrtcDetectedBrowser = "chrome";
-
-  isSupported = true; // TODO: remove me
 
   // Set Opus as the default audio codec if it's present.
   function preferOpus(sdp) {


### PR DESCRIPTION
# Overview

* Handle existing errors more accurately, including:
  * Account for what seems like a _change_ in WebRTC error behavior
  * Fixing #31 (proper error message for user not giving permission)
* Handle a few more errors

---

# The Most Interesting Part

So here's a couple very fun facts:

* In some browsers (I suspect slightly old ones), `NotAllowedError` would mean _either_ that the user disallowed access to the camera/mic, _or_ the connection was insecure. As such, the only way I can think of distinguishing them is by checking for `https` (as we sortof were before I "fixed" it in a previous PR)
* In other browsers (I suspect the most recent), `NotAllowedError` thankfully only means that the user disallowed access to the camera/mic. However, insecure connections are instead handled by hiding `navigator.mediaDevices`, `navigator.getUserMedia`, and possibly other things. The absence of those things _used_ to be our way of testing for outdated browsers. So now, we need a way to distinguish between insecure and outdated, and the best way I can think of is to check for the existence of some other fields.

So we had to handle all that. The polyfill was already handling missing `getUserMedia` as an "unsupported" error, so I changed it to distinguish between the "unsupported" and "insecure" errors and return accordingly. I let the function that calls `getUserMedia` continue to handle all errors by giving an appropriate user message, but now I include the two potentially returned by the polyfill and I disambiguate `NotAllowedError`.

---

# Question

As a separate matter, I wonder whether `getUserMediaPolyfill` is technically a polyfill anymore. By definition it looks like they're supposed to make older browsers behave like newer ones. Here, I'm making newer browsers behave like older ones, because it's just easier to handle errors this way. So the options I can think of:

* Leave it as I wrote it if it's not a big deal
* Rename the file
* Move logic around so that it technically stays a polyfill.