### PR TITLE
WIP - Audio/Video Disabled by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+// TODO - test on Firefox as well
+// TODO - figure out weird glitchy sizing thing on startup. seems to just be when video.enabled is false. test that alone on master. if it still happens, ship it.
 // vim: et:ts=2:sw=2:sts=2:ft=javascript
 /**
  * Copyright 2013 j <j@mailb.org>
@@ -84,6 +86,7 @@ exports.clientVars = function(hook, context, callback)
   }
 
   audio = getDisabledDefault('audio');
+  video = getDisabledDefault('video');
 
   var iceServers = [ {"url": "stun:stun.l.google.com:19302"} ];
   if(settings.ep_webrtc && settings.ep_webrtc.iceServers){
@@ -99,8 +102,11 @@ exports.clientVars = function(hook, context, callback)
     webrtc: {
       "iceServers": iceServers,
       "enabled": enabled,
+      // TODO - I need to rename audio_enabled/video_enabled. "enabled" means something different than audioTrack.enabled
       "audio_enabled": audio.enabled,
       "audio_default_on": audio.defaultOn,
+      "video_enabled": video.enabled,
+      "video_default_on": video.defaultOn,
       "listenClass": listenClass
     }
   });
@@ -133,9 +139,14 @@ exports.eejsBlock_mySettings = function (hook, context, callback)
       ? true
       : false;
 
+    var videoEnabled = (settings.ep_webrtc && settings.ep_webrtc.video !== "disabled")
+      ? true
+      : false;
+
     context.content += eejs.require('ep_webrtc/templates/settings.ejs', {
       enabled : enabled,
       audio_enabled : audioEnabled,
+      video_enabled : videoEnabled,
     });
     callback();
 };

--- a/index.js
+++ b/index.js
@@ -58,6 +58,24 @@ function handleRTCMessage(client, payload)
   }
 }
 
+getDisabledDefault = function(field)
+{
+  // TODO - have a settings.json.template type thing
+  if (settings.ep_webrtc) {
+    if (settings.ep_webrtc[field] === "disabled") {
+      // defaultOn should be ignored in this case
+      return {enabled: false}
+    } else if (settings.ep_webrtc[field] === "default_off") {
+      return {enabled: true, defaultOn: false}
+    } else if (settings.ep_webrtc[field] === "default_on" || settings.ep_webrtc[field] === undefined) {
+      return {enabled: true, defaultOn: true}
+    } else {
+      // TODO - useless since you can change it in the admin?
+      throw Error("invalid value for setting ep_webrtc." + field + ": " + settings.ep_webrtc[field])
+    }
+  }
+}
+
 exports.clientVars = function(hook, context, callback)
 {
   var enabled = true;
@@ -65,24 +83,7 @@ exports.clientVars = function(hook, context, callback)
     enabled = settings.ep_webrtc.enabled;
   }
 
-  // TODO - have a settings.json.template type thing
-  var audioEnabled
-  var audioDefaultOn
-  if (settings.ep_webrtc) {
-    if (settings.ep_webrtc.audio === "disabled") {
-      audioEnabled = false
-      // audioDefaultOn should be ignored in this case
-    } else if (settings.ep_webrtc.audio === "default_on") {
-      audioEnabled = true
-      audioDefaultOn = true
-    } else if (settings.ep_webrtc.audio === "default_off") {
-      audioEnabled = true
-      audioDefaultOn = false
-    } else {
-      // TODO - useless since you can change it in the admin?
-      throw Error("invalid value for setting ep_webrtc.audio: " + settings.ep_webrtc.audio)
-    }
-  }
+  audio = getDisabledDefault('audio');
 
   var iceServers = [ {"url": "stun:stun.l.google.com:19302"} ];
   if(settings.ep_webrtc && settings.ep_webrtc.iceServers){
@@ -98,8 +99,8 @@ exports.clientVars = function(hook, context, callback)
     webrtc: {
       "iceServers": iceServers,
       "enabled": enabled,
-      "audio_enabled": audioEnabled,
-      "audio_default_on": audioDefaultOn,
+      "audio_enabled": audio.enabled,
+      "audio_default_on": audio.defaultOn,
       "listenClass": listenClass
     }
   });

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 // TODO - test on Firefox as well
+// TODO - test with conversation with multiple ppl
 // vim: et:ts=2:sw=2:sts=2:ft=javascript
 /**
  * Copyright 2013 j <j@mailb.org>

--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ function handleRTCMessage(client, payload)
   }
 }
 
+// TODO - axe this function in favor of all booleans
 getDisabledDefault = function(field)
 {
   // TODO - have a settings.json.template type thing
@@ -84,6 +85,7 @@ exports.clientVars = function(hook, context, callback)
     enabled = settings.ep_webrtc.enabled;
   }
 
+  // TODO - Rename settings: https://github.com/ether/ep_webrtc/pull/40/files#r416660488
   audio = getDisabledDefault('audio');
   video = getDisabledDefault('video');
 
@@ -101,7 +103,6 @@ exports.clientVars = function(hook, context, callback)
     webrtc: {
       "iceServers": iceServers,
       "enabled": enabled,
-      // TODO - I need to rename audio_enabled/video_enabled. "enabled" means something different than audioTrack.enabled
       "audio_enabled": audio.enabled,
       "audio_default_on": audio.defaultOn,
       "video_enabled": video.enabled,
@@ -129,7 +130,6 @@ exports.setSocketIO = function (hook, context, callback)
 
 exports.eejsBlock_mySettings = function (hook, context, callback)
 {
-    // TODO - Double check this still works. Don't rely on the javascript
     var enabled = (settings.ep_webrtc && settings.ep_webrtc.enabled === false)
       ? 'unchecked'
       : 'checked';

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 // TODO - test on Firefox as well
-// TODO - figure out weird glitchy sizing thing on startup. seems to just be when video.enabled is false. test that alone on master. if it still happens, ship it.
 // vim: et:ts=2:sw=2:sts=2:ft=javascript
 /**
  * Copyright 2013 j <j@mailb.org>

--- a/index.js
+++ b/index.js
@@ -65,6 +65,12 @@ exports.clientVars = function(hook, context, callback)
     enabled = settings.ep_webrtc.enabled;
   }
 
+  // TODO - have a settings.json.template type thing
+  var audio_default_muted = true;
+  if(settings.ep_webrtc && settings.ep_webrtc.audio_default_muted === false){
+    audio_default_muted = settings.ep_webrtc.audio_default_muted;
+  }
+
   var iceServers = [ {"url": "stun:stun.l.google.com:19302"} ];
   if(settings.ep_webrtc && settings.ep_webrtc.iceServers){
     iceServers = settings.ep_webrtc.iceServers;
@@ -79,6 +85,7 @@ exports.clientVars = function(hook, context, callback)
     webrtc: {
       "iceServers": iceServers,
       "enabled": enabled,
+      "audio_default_muted": audio_default_muted,
       "listenClass": listenClass
     }
   });

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ exports.clientVars = function(hook, context, callback)
       audioEnabled = true
       audioDefaultOn = false
     } else {
+      // TODO - useless since you can change it in the admin?
       throw Error("invalid value for setting ep_webrtc.audio: " + settings.ep_webrtc.audio)
     }
   }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-// TODO - test with conversation with multiple ppl
 // vim: et:ts=2:sw=2:sts=2:ft=javascript
 /**
  * Copyright 2013 j <j@mailb.org>

--- a/index.js
+++ b/index.js
@@ -66,9 +66,21 @@ exports.clientVars = function(hook, context, callback)
   }
 
   // TODO - have a settings.json.template type thing
-  var audio_default_muted = true;
-  if(settings.ep_webrtc && settings.ep_webrtc.audio_default_muted === false){
-    audio_default_muted = settings.ep_webrtc.audio_default_muted;
+  var audioEnabled
+  var audioDefaultOn
+  if (settings.ep_webrtc) {
+    if (settings.ep_webrtc.audio === "disabled") {
+      audioEnabled = false
+      // audioDefaultOn should be ignored in this case
+    } else if (settings.ep_webrtc.audio === "default_on") {
+      audioEnabled = true
+      audioDefaultOn = true
+    } else if (settings.ep_webrtc.audio === "default_off") {
+      audioEnabled = true
+      audioDefaultOn = false
+    } else {
+      throw Error("invalid value for setting ep_webrtc.audio: " + settings.ep_webrtc.audio)
+    }
   }
 
   var iceServers = [ {"url": "stun:stun.l.google.com:19302"} ];
@@ -85,7 +97,8 @@ exports.clientVars = function(hook, context, callback)
     webrtc: {
       "iceServers": iceServers,
       "enabled": enabled,
-      "audio_default_muted": audio_default_muted,
+      "audio_enabled": audioEnabled,
+      "audio_default_on": audioDefaultOn,
       "listenClass": listenClass
     }
   });
@@ -109,11 +122,18 @@ exports.setSocketIO = function (hook, context, callback)
 
 exports.eejsBlock_mySettings = function (hook, context, callback)
 {
-    var checked = (settings.ep_webrtc && settings.ep_webrtc.enabled === false)
+    // TODO - Double check this still works. Don't rely on the javascript
+    var enabled = (settings.ep_webrtc && settings.ep_webrtc.enabled === false)
       ? 'unchecked'
       : 'checked';
+
+    var audioEnabled = (settings.ep_webrtc && settings.ep_webrtc.audio !== "disabled")
+      ? true
+      : false;
+
     context.content += eejs.require('ep_webrtc/templates/settings.ejs', {
-      checked : checked
+      enabled : enabled,
+      audio_enabled : audioEnabled,
     });
     callback();
 };

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-// TODO - test on Firefox as well
 // TODO - test with conversation with multiple ppl
 // vim: et:ts=2:sw=2:sts=2:ft=javascript
 /**
@@ -73,8 +72,8 @@ exports.clientVars = function(hook, context, callback)
   }
 
   var audioEnabledOnStart = true;
-  if(settings.ep_webrtc && settings.ep_webrtc.audio_enabled_on_start === false){
-    audioEnabledOnStart = settings.ep_webrtc.audio_enabled_on_start;
+  if(settings.ep_webrtc && settings.ep_webrtc.audio_enabled_on_start_default === false){
+    audioEnabledOnStart = settings.ep_webrtc.audio_enabled_on_start_default;
   }
 
   var videoAllowed = true;
@@ -82,8 +81,8 @@ exports.clientVars = function(hook, context, callback)
     videoAllowed = settings.ep_webrtc.video_allowed;
   }
   var videoEnabledOnStart = true;
-  if(settings.ep_webrtc && settings.ep_webrtc.video_enabled_on_start === false){
-    videoEnabledOnStart = settings.ep_webrtc.video_enabled_on_start;
+  if(settings.ep_webrtc && settings.ep_webrtc.video_enabled_on_start_default === false){
+    videoEnabledOnStart = settings.ep_webrtc.video_enabled_on_start_default;
   }
 
   var iceServers = [ {"url": "stun:stun.l.google.com:19302"} ];
@@ -101,9 +100,9 @@ exports.clientVars = function(hook, context, callback)
       "iceServers": iceServers,
       "enabled": enabled,
       "audio_allowed": audioAllowed,
-      "audio_enabled_on_start": audioEnabledOnStart,
+      "audio_enabled_on_start_default": audioEnabledOnStart,
       "video_allowed": videoAllowed,
-      "video_enabled_on_start": videoEnabledOnStart,
+      "video_enabled_on_start_default": videoEnabledOnStart,
       "listenClass": listenClass
     }
   });

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,5 +1,5 @@
 {
     "pad.settings.enablertc": "Enable Audio/Video Chat",
-    "pad.settings.audiodefaulton": "Audio On At Start",
-    "pad.settings.videodefaulton": "Video On At Start"
+    "pad.settings.audioenabledonstart": "Audio On At Start",
+    "pad.settings.videoenabledonstart": "Video On At Start"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,5 @@
 {
     "pad.settings.enablertc": "Enable Audio/Video Chat",
-    "pad.settings.audiodefaulton": "Audio On At Start"
+    "pad.settings.audiodefaulton": "Audio On At Start",
+    "pad.settings.videodefaulton": "Video On At Start"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,4 @@
 {
     "pad.settings.enablertc": "Enable Audio/Video Chat",
-    "pad.settings.audiodefaultmuted": "Mute by Default"
+    "pad.settings.audiodefaulton": "Audio On At Start"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,3 +1,4 @@
 {
-    "pad.settings.enablertc": "Enable Audio/Video Chat"
+    "pad.settings.enablertc": "Enable Audio/Video Chat",
+    "pad.settings.audiodefaultmuted": "Mute by Default"
 }

--- a/static/css/webrtc.css
+++ b/static/css/webrtc.css
@@ -50,19 +50,21 @@
   margin-right: 6px;
   cursor: pointer;
   transition: opacity .2s, background-color .2s;
-  color: #333;
+  color: rgba(51, 51, 51, 1);
   width: 28px;
   height: 28px;
 }
-.interface-btn:hover {
+.interface-btn:hover:not(.disallowed) {
   opacity: 1;
   background-color: white !important;
 }
 .interface-btn.audio-btn:before { content: '\e83d'; }
 .interface-btn.audio-btn.muted:before { content: '\e83e'; }
+.interface-btn.audio-btn.disallowed:before { color: rgba(51, 51, 51, .5); }
 
 .interface-btn.video-btn:before { content: '\e83b'; }
 .interface-btn.video-btn.off:before { content: '\e83c'; }
+.interface-btn.video-btn.disallowed:before { color: rgba(51, 51, 51, .5); }
 
 .interface-btn.enlarge-btn:before { content: '\e840'; }
 .interface-btn.enlarge-btn.large:before { content: '\e83f'; }

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -268,7 +268,7 @@ var rtc = (function() {
 
       // TODO - is audio_enabled/video_enabled a security issue? Like do we care if the user hacks the client to do video anyway?
       // I suppose this has nothing to do with the server anyway. It uses Google turn servers etc
-      if (clientVars.webrtc.audio_allowed || !isLocal) {
+      if (clientVars.webrtc.audio_allowed) {
         $mute.on({
           click: function(event) {
             var muted;

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -517,7 +517,9 @@ var rtc = (function() {
           localStream = stream;
           var audioTrack = localStream.getAudioTracks()[0];
           if (audioTrack) {
-            audioTrack.enabled = $("#options-audiodefaulton").prop("checked");
+            // using `=== true` to make absolutely sure the result is a boolean
+            // we don't want bugs when it comes to muting/turning off video
+            audioTrack.enabled = $("#options-audiodefaulton").prop("checked") === true;
           }
           self.setStream(self._pad.getUserId(), stream);
           self._pad.collabClient.getConnectedUsers().forEach(function(user) {

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -247,6 +247,10 @@ var rtc = (function() {
       var videoId = "video_" + userId.replace(/\./g, "_");
       var $video = $("#" + videoId);
 
+      ///////
+      // Mute button
+      ///////
+
       var audioTrack = stream.getAudioTracks()[0];
       var initiallyMuted = false;
       if (audioTrack) {
@@ -279,6 +283,10 @@ var rtc = (function() {
         }
       });
 
+      ///////
+      // Disable Video button
+      ///////
+
       var videoTrack = stream.getVideoTracks()[0];
       var initiallyVideoEnabled = false;
       if (videoTrack) {
@@ -308,6 +316,10 @@ var rtc = (function() {
         }
       }
 
+      ///////
+      // Enlarge Video button
+      ///////
+
       var videoEnlarged = false;
       var $largeVideo = $("<span class='interface-btn enlarge-btn buttonicon'>")
         .attr("title", "Make video larger")
@@ -331,6 +343,11 @@ var rtc = (function() {
             $video.parent().toggleClass('large', videoEnlarged)
           }
         });
+
+
+      ///////
+      // Combining
+      ///////
 
       $("#interface_" + videoId).remove();
       $("<div class='interface-container'>")

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -186,14 +186,14 @@ var rtc = (function() {
       var audioTrack = localStream.getAudioTracks()[0];
       if (audioTrack) {
         audioTrack.enabled = !audioTrack.enabled;
-        return !audioTrack.enabled;
+        return !audioTrack.enabled; // returning "Muted" state, which is !enabled
       }
     },
     toggleVideo: function() {
       var videoTrack = localStream.getVideoTracks()[0];
       if (videoTrack) {
         videoTrack.enabled = !videoTrack.enabled;
-        return !videoTrack.enabled;
+        return videoTrack.enabled;
       }
     },
     getUserFromId: function(userId) {
@@ -282,14 +282,12 @@ var rtc = (function() {
           }
         });
       }
-      var videoEnabled = true;
       var $disableVideo = isLocal
         ? $("<span class='interface-btn video-btn buttonicon'>")
             .attr("title", "Disable video")
             .on({
               click: function(event) {
-                self.toggleVideo();
-                videoEnabled = !videoEnabled;
+                var videoEnabled = self.toggleVideo();
                 $disableVideo
                   .attr(
                     "title",

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -506,7 +506,7 @@ var rtc = (function() {
           localStream = stream;
           var audioTrack = localStream.getAudioTracks()[0];
           if (audioTrack) {
-            audioTrack.enabled = !clientVars.webrtc.audio_default_muted;
+            audioTrack.enabled = !$("#options-audiodefaultmuted").prop("checked");
           }
           self.setStream(self._pad.getUserId(), stream);
           self._pad.collabClient.getConnectedUsers().forEach(function(user) {
@@ -527,7 +527,17 @@ var rtc = (function() {
         return false;
       }
     },
+    initOptions: function() {
+      var audioDefaultMuted = padcookie.getPref("audioDefaultMuted");
+      if (typeof audioDefaultMuted !== "undefined") {
+        $("#options-audiodefaultmuted").prop("checked", audioDefaultMuted);
+      }
+      $("#options-audiodefaultmuted").on("change", function() {
+        padcookie.setPref("audioDefaultMuted", this.checked);
+      });
+    },
     init: function(pad) {
+      self.initOptions()
       self._pad = pad || window.pad;
       var rtcEnabled = padcookie.getPref("rtcEnabled");
       if (typeof rtcEnabled == "undefined") {

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -258,9 +258,9 @@ var rtc = (function() {
       }
 
       var $mute = $("<span class='interface-btn audio-btn buttonicon'>")
-        .attr("title", clientVars.webrtc.audio_enabled
+        .attr("title", clientVars.webrtc.audio_allowed
           ? (initiallyMuted ? "Unmute" : "Mute")
-          : "Audio disabled by admin")
+          : "Audio disallowed by admin")
         .toggleClass("muted", initiallyMuted)
 
       // TODO - is audio_enabled/video_enabled a security issue? Like do we care if the user hacks the client to do video anyway?
@@ -268,7 +268,7 @@ var rtc = (function() {
       $mute.on({
         click: function(event) {
           var muted;
-          if (isLocal && !clientVars.webrtc.audio_enabled) {
+          if (isLocal && !clientVars.webrtc.audio_allowed) {
             return
           }
           if (isLocal) {
@@ -296,12 +296,12 @@ var rtc = (function() {
       var $disableVideo = null
       if (isLocal) {
         $disableVideo = $("<span class='interface-btn video-btn buttonicon'>")
-          .attr("title", clientVars.webrtc.video_enabled
+          .attr("title", clientVars.webrtc.video_allowed
             ? (initiallyVideoEnabled ? "Disable video" : "Enable video")
-            : "Video disabled by admin" // TODO - greyed out or something for CSS?)
+            : "Video disallowed by admin" // TODO - greyed out or something for CSS?)
           )
           .toggleClass("off", !initiallyVideoEnabled);
-        if (clientVars.webrtc.video_enabled) {
+        if (clientVars.webrtc.video_allowed) {
           $disableVideo.on({
             click: function(event) {
               var videoEnabled = self.toggleVideo();
@@ -545,11 +545,11 @@ var rtc = (function() {
           // using `.prop("checked") === true` to make absolutely sure the result is a boolean
           // we don't want bugs when it comes to muting/turning off video
           if (audioTrack) {
-            audioTrack.enabled = $("#options-audiodefaulton").prop("checked") === true;
+            audioTrack.enabled = $("#options-audioenabledonstart").prop("checked") === true;
           }
           var videoTrack = localStream.getVideoTracks()[0];
           if (videoTrack) {
-            videoTrack.enabled = $("#options-videodefaulton").prop("checked") === true;
+            videoTrack.enabled = $("#options-videoenabledonstart").prop("checked") === true;
           }
           self.setStream(self._pad.getUserId(), stream);
           self._pad.collabClient.getConnectedUsers().forEach(function(user) {
@@ -612,23 +612,23 @@ var rtc = (function() {
     init: function(pad) {
       self._pad = pad || window.pad;
 
-      // The checkbox shouldn't even exist if it's not enabled
-      if (clientVars.webrtc.audio_enabled) {
+      // The checkbox shouldn't even exist if audio is not allowed
+      if (clientVars.webrtc.audio_allowed) {
         self.settingToCheckbox({ // TODO - object literals - too modern of js?
-          urlVar: "audiodefault",
-          cookie: "audioDefaultOn",
-          clientVar: "audio_default_on",
-          checkboxId: "#options-audiodefaulton"
+          urlVar: "webrtcaudioenabled",
+          cookie: "audioEnabledOnStart",
+          clientVar: "audio_enabled_on_start",
+          checkboxId: "#options-audioenabledonstart"
         })
       }
 
-      // The checkbox shouldn't even exist if it's not enabled
-      if (clientVars.webrtc.video_enabled) {
+      // The checkbox shouldn't even exist if video is not allowed
+      if (clientVars.webrtc.video_allowed) {
         self.settingToCheckbox({
-          urlVar: "videodefault",
-          cookie: "videoDefaultOn",
-          clientVar: "video_default_on",
-          checkboxId: "#options-videodefaulton"
+          urlVar: "webrtcvideoenabled",
+          cookie: "videoEnabledOnStart",
+          clientVar: "video_enabled_on_start",
+          checkboxId: "#options-videoenabledonstart"
         })
       }
 

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -578,12 +578,12 @@ var rtc = (function() {
     // It will check for the value in urlVar, cookie, and clientVar, in that order
     // If urlVar is found, it will also set the cookie
     // Finally, it sets up to set cookie if the user changes the setting in the gearbox
-    settingToCheckbox: function({urlVar, cookie, clientVar, checkboxId}) {
-      if (!urlVar) {throw Error("missing urlVar in settingToCheckbox");}
-      if (!cookie) {throw Error("missing cookie in settingToCheckbox");}
-      if (!clientVar) {throw Error("missing clientVar in settingToCheckbox");}
-      if (!(clientVar in clientVars.webrtc)) {throw Error("unknown clientVar: " + clientVar);}
-      if (!checkboxId) {throw Error("missing checkboxId in settingToCheckbox");}
+    settingToCheckbox: function(params) {
+      if (!params.urlVar) {throw Error("missing urlVar in settingToCheckbox");}
+      if (!params.cookie) {throw Error("missing cookie in settingToCheckbox");}
+      if (!params.clientVar) {throw Error("missing clientVar in settingToCheckbox");}
+      if (!(params.clientVar in clientVars.webrtc)) {throw Error("unknown clientVar: " + params.clientVar + " in settingToCheckbox");}
+      if (!params.checkboxId) {throw Error("missing checkboxId in settingToCheckbox");}
 
       var value
 
@@ -591,24 +591,24 @@ var rtc = (function() {
       // * If the setting is not in the URL: try to get it from the cookie
       // * If the setting was in neither, go with the site-wide setting in clientVar
       //   but don't put it in the cookies
-      if (window.location.search.indexOf(urlVar + "=true") > -1) {
-        padcookie.setPref(cookie, true);
+      if (window.location.search.indexOf(params.urlVar + "=true") > -1) {
+        padcookie.setPref(params.cookie, true);
         value = true
-      } else if (window.location.search.indexOf(urlVar + "=false") > -1) {
-        padcookie.setPref(cookie, false);
+      } else if (window.location.search.indexOf(params.urlVar + "=false") > -1) {
+        padcookie.setPref(params.cookie, false);
         value = false
       } else {
-        value = padcookie.getPref(cookie);
+        value = padcookie.getPref(params.cookie);
         if (typeof value === "undefined") {
-          value = clientVars.webrtc[clientVar];
+          value = clientVars.webrtc[params.clientVar];
         }
       }
 
-      $(checkboxId).prop("checked", value);
+      $(params.checkboxId).prop("checked", value);
 
       // If the user changes the checkbox, set the cookie accordingly
-      $(checkboxId).on("change", function() {
-        padcookie.setPref(cookie, this.checked);
+      $(params.checkboxId).on("change", function() {
+        padcookie.setPref(params.cookie, this.checked);
       });
     },
     init: function(pad) {
@@ -616,7 +616,7 @@ var rtc = (function() {
 
       // The checkbox shouldn't even exist if audio is not allowed
       if (clientVars.webrtc.audio_allowed) {
-        self.settingToCheckbox({ // TODO - object literals - too modern of js?
+        self.settingToCheckbox({
           urlVar: "webrtcaudioenabled",
           cookie: "audioEnabledOnStart",
           clientVar: "audio_enabled_on_start",

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -528,7 +528,20 @@ var rtc = (function() {
       }
     },
     initOptions: function() {
-      var audioDefaultMuted = padcookie.getPref("audioDefaultMuted");
+      var audioDefaultMuted
+
+      // If the setting is in the URL, set the cookie
+      if (window.location.search.indexOf("defaultmuted=YES") > -1) {
+        padcookie.setPref("audioDefaultMuted", true);
+        audioDefaultMuted = true
+      } else if (window.location.search.indexOf("defaultmuted=NO") > -1) {
+        padcookie.setPref("audioDefaultMuted", false);
+        audioDefaultMuted = false
+      } else {
+        // If the setting is not in the URL, get the cookie
+        audioDefaultMuted = padcookie.getPref("audioDefaultMuted");
+      }
+      // Could be "undefined" if we tried to get the cookie and it wasn't there
       if (typeof audioDefaultMuted !== "undefined") {
         $("#options-audiodefaultmuted").prop("checked", audioDefaultMuted);
       }

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -541,7 +541,7 @@ var rtc = (function() {
       }
     },
     initOptions: function() {
-      var audioDefaultOn
+      var value
 
       // Ignore "default on" if it's not enabled at all
       if (!clientVars.webrtc.audio_enabled) {
@@ -550,23 +550,22 @@ var rtc = (function() {
 
       // * If the setting is in the URL: use it, and also set the cookie
       // * If the setting is not in the URL: try to get it from the cookie
+      // * If the setting was in neither, go with the site-wide settings
+      //   but don't put it in the cookies
       if (window.location.search.indexOf("audiodefault=ON") > -1) {
         padcookie.setPref("audioDefaultOn", true);
-        audioDefaultOn = true
+        value = true
       } else if (window.location.search.indexOf("audiodefault=OFF") > -1) {
         padcookie.setPref("audioDefaultOn", false);
-        audioDefaultOn = false
+        value = false
       } else {
-        audioDefaultOn = padcookie.getPref("audioDefaultOn");
+        value = padcookie.getPref("audioDefaultOn");
+        if (typeof value === "undefined") {
+          value = clientVars.webrtc.audio_default_on;
+        }
       }
 
-      // * If audioDefaultOn was in the cookie or the URL var, set the checkbox accordingly
-      // * If audioDefaultOn was not in the cookie, go with the site-wide settings
-      if (typeof audioDefaultOn !== "undefined") {
-        $("#options-audiodefaulton").prop("checked", audioDefaultOn);
-      } else {
-        $("#options-audiodefaulton").prop("checked", clientVars.webrtc.audio_default_on);
-      }
+      $("#options-audiodefaulton").prop("checked", value);
 
       // If the user changes the checkbox, set the cookie accordingly
       $("#options-audiodefaulton").on("change", function() {

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -619,7 +619,7 @@ var rtc = (function() {
         self.settingToCheckbox({
           urlVar: "webrtcaudioenabled",
           cookie: "audioEnabledOnStart",
-          clientVar: "audio_enabled_on_start",
+          clientVar: "audio_enabled_on_start_default",
           checkboxId: "#options-audioenabledonstart"
         })
       }
@@ -629,7 +629,7 @@ var rtc = (function() {
         self.settingToCheckbox({
           urlVar: "webrtcvideoenabled",
           cookie: "videoEnabledOnStart",
-          clientVar: "video_enabled_on_start",
+          clientVar: "video_enabled_on_start_default",
           checkboxId: "#options-videoenabledonstart"
         })
       }

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -185,6 +185,7 @@ var rtc = (function() {
     toggleMuted: function() {
       if (!clientVars.webrtc.audio_enabled) {
         // If audio is disabled, don't let us toggle it
+        // TODO - make sure this doesn't change title. it happens in the calling function
         return true
       }
       var audioTrack = localStream.getAudioTracks()[0];

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -183,11 +183,6 @@ var rtc = (function() {
     // TODO - is audio_enabled a security issue? Do we care if the user hacks the client to do video anyway?
     // I suppose this has nothing to do with the server anyway. It uses Google turn servers etc
     toggleMuted: function() {
-      if (!clientVars.webrtc.audio_enabled) {
-        // If audio is disabled, don't let us toggle it
-        // TODO - make sure this doesn't change title. it happens in the calling function
-        return true
-      }
       var audioTrack = localStream.getAudioTracks()[0];
       if (audioTrack) {
         audioTrack.enabled = !audioTrack.enabled;
@@ -270,7 +265,9 @@ var rtc = (function() {
       var $mute = $("<span class='interface-btn audio-btn buttonicon'>")
         .attr("title", title)
         .toggleClass("muted", initiallyMuted)
-        .on({
+
+      if (clientVars.webrtc.audio_enabled) {
+        $mute.on({
           click: function(event) {
             var muted;
             if (isLocal) {
@@ -284,6 +281,7 @@ var rtc = (function() {
               .toggleClass("muted", muted);
           }
         });
+      }
       var videoEnabled = true;
       var $disableVideo = isLocal
         ? $("<span class='interface-btn video-btn buttonicon'>")

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -262,6 +262,7 @@ var rtc = (function() {
           ? (initiallyMuted ? "Unmute" : "Mute")
           : "Audio disallowed by admin")
         .toggleClass("muted", initiallyMuted)
+        .toggleClass("disallowed", !clientVars.webrtc.audio_allowed);
 
       // TODO - is audio_enabled/video_enabled a security issue? Like do we care if the user hacks the client to do video anyway?
       // I suppose this has nothing to do with the server anyway. It uses Google turn servers etc
@@ -298,9 +299,10 @@ var rtc = (function() {
         $disableVideo = $("<span class='interface-btn video-btn buttonicon'>")
           .attr("title", clientVars.webrtc.video_allowed
             ? (initiallyVideoEnabled ? "Disable video" : "Enable video")
-            : "Video disallowed by admin" // TODO - greyed out or something for CSS?)
+            : "Video disallowed by admin"
           )
-          .toggleClass("off", !initiallyVideoEnabled);
+          .toggleClass("off", !initiallyVideoEnabled)
+          .toggleClass("disallowed", !clientVars.webrtc.video_allowed);
         if (clientVars.webrtc.video_allowed) {
           $disableVideo.on({
             click: function(event) {

--- a/templates/settings.ejs
+++ b/templates/settings.ejs
@@ -8,3 +8,9 @@
     <label for="options-audiodefaulton" data-l10n-id="pad.settings.audiodefaulton">Audio On At Start</label>
   </p>
 <% } %>
+<% if (video_enabled) { %>
+  <p>
+    <input type="checkbox" id="options-videodefaulton" ></input>
+    <label for="options-videodefaulton" data-l10n-id="pad.settings.videodefaulton">Video On At Start</label>
+  </p>
+<% } %>

--- a/templates/settings.ejs
+++ b/templates/settings.ejs
@@ -2,15 +2,15 @@
   <input type="checkbox" id="options-enablertc" <%= enabled %>></input>
   <label for="options-enablertc" data-l10n-id="pad.settings.enablertc">Enable Audio/Video Chat</label>
 </p>
-<% if (audio_enabled) { %>
+<% if (audio_allowed) { %>
   <p>
-    <input type="checkbox" id="options-audiodefaulton" ></input>
-    <label for="options-audiodefaulton" data-l10n-id="pad.settings.audiodefaulton">Audio On At Start</label>
+    <input type="checkbox" id="options-audioenabledonstart" ></input>
+    <label for="options-audioenabledonstart" data-l10n-id="pad.settings.audioenabledonstart">Audio On At Start</label>
   </p>
 <% } %>
-<% if (video_enabled) { %>
+<% if (video_allowed) { %>
   <p>
-    <input type="checkbox" id="options-videodefaulton" ></input>
-    <label for="options-videodefaulton" data-l10n-id="pad.settings.videodefaulton">Video On At Start</label>
+    <input type="checkbox" id="options-videoenabledonstart" ></input>
+    <label for="options-videoenabledonstart" data-l10n-id="pad.settings.videoenabledonstart">Video On At Start</label>
   </p>
 <% } %>

--- a/templates/settings.ejs
+++ b/templates/settings.ejs
@@ -1,8 +1,10 @@
 <p>
-  <input type="checkbox" id="options-enablertc" <%= checked %>></input>
+  <input type="checkbox" id="options-enablertc" <%= enabled %>></input>
   <label for="options-enablertc" data-l10n-id="pad.settings.enablertc">Enable Audio/Video Chat</label>
 </p>
-<p>
-  <input type="checkbox" id="options-audiodefaultmuted" <%= checked %>></input>
-  <label for="options-audiodefaultmuted" data-l10n-id="pad.settings.audiodefaultmuted">Mute by Default</label>
-</p>
+<% if (audio_enabled) { %>
+  <p>
+    <input type="checkbox" id="options-audiodefaulton" ></input>
+    <label for="options-audiodefaulton" data-l10n-id="pad.settings.audiodefaulton">Audio On At Start</label>
+  </p>
+<% } %>

--- a/templates/settings.ejs
+++ b/templates/settings.ejs
@@ -1,2 +1,8 @@
-<input type="checkbox" id="options-enablertc" <%= checked %>></input>
-<label for="options-enablertc" data-l10n-id="pad.settings.enablertc">Enable Audio/Video Chat</label>
+<p>
+  <input type="checkbox" id="options-enablertc" <%= checked %>></input>
+  <label for="options-enablertc" data-l10n-id="pad.settings.enablertc">Enable Audio/Video Chat</label>
+</p>
+<p>
+  <input type="checkbox" id="options-audiodefaultmuted" <%= checked %>></input>
+  <label for="options-audiodefaultmuted" data-l10n-id="pad.settings.audiodefaultmuted">Mute by Default</label>
+</p>


### PR DESCRIPTION
**Early PR**:
* Am I on the right track?
* You can give this a try if you want.
* Audio only so far.

**Functionality so far, matching requirements inferred from #23**:
* in setting.json, `ep_webrtc.audio` can be "disabled", "default_off", or "default_on" (which is the default)
* Changing the checkbox saves to cookies
* Setting `audiodefault=ON` or `audiodefault=OFF` accordingly sets the checkbox and the cookie on page load.

The code could use some cleanup. In particular once I add the same for video I can reduce a fair amount of duplication.