### PR TITLE
Let user cookies override settings for "Enable Audio/Video Chat"

### DIFF
--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -532,12 +532,10 @@ var rtc = (function() {
         });
       }
 
-      if (clientVars.webrtc.enabled) {
-        if (rtcEnabled) {
-          self.activate();
-        } else {
-          self.deactivate();
-        }
+      if (rtcEnabled) {
+        self.activate();
+      } else {
+        self.deactivate();
       }
       $("#options-enablertc").on("change", function() {
         if (this.checked) {


### PR DESCRIPTION
@JohnMcLear per our conversation in #23 it sounded like you wanted users to be able to override `settings.json` with cookies or URL vars. However currently, this is not _entirely_ the case for the existing setting (`ep_webrtc.enabled`).

The override fails if:
* `ep_webrtc.enabled` is set to `false` and the cookie is set to `true`.

The override does succeed if:
* `ep_webrtc.enabled` is set to `true` and the cookie is set to `false`.
* The user uses the URL var (both `false` to `true` and `true` to `false`)

It looks as though this may have been deliberate. I'm not sure what the idea was, though. Here's the relevant change and PR: 886ab4f8 #9 

My change here lets the user override with the cookies, and of course continues to allow them to override with URL vars. However, if you really meant for the override to go from `true` to `false` but not `false` to `true`, I could instead put that same restriction on the URL vars for consistency.