### PR TITLE
Error stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ active users of the pad using WebRTC.
 
 ## Post installation
 
-You should use a STUN/TURN server to ensure consistant connecivty between clients.  See STUN/TURN in settings. 
+You should use a STUN/TURN server to ensure consistant connecivty between clients.  See STUN/TURN in settings.
 
 # Settings
 
@@ -66,6 +66,19 @@ To set an element or class to listen for an init event set `ep_webrtc.listenClas
     }
 
 To enable webrtc with a URL parameter append the following to your pad URL ``?av=YES``
+
+## Metrics
+
+You can see metrics for various errors that users have when attempting to connect their camera/microphone:
+
+* `ep_webrtc_err_Hardware`: Some sort of hardware-related connection problem on the users' computer.
+* `ep_webrtc_err_NotFound`: Could not find user's camera/microphone.
+* `ep_webrtc_err_Abort`: Some sort of other, non-hardware related connection problem on the user's computer.
+* `ep_webrtc_err_NotSupported`: User's environment does not support webrtc.
+* `ep_webrtc_err_Permission`: User did not grant permission to their camera/microphone
+* `ep_webrtc_err_SecureConnection`: Etherpad is not set up on a secure connection, which is requried for webrtc
+* `ep_webrtc_err_Unknown`: Some other unspecified error. Perhaps a bug in this plugin.
+* `ep_webrtc_err_Invalid`: Invalid error report. Either a bug in this plugin or a mischievous user.
 
 # Developing and contributing
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ You can see metrics for various errors that users have when attempting to connec
 * `ep_webrtc_err_Permission`: User did not grant permission to their camera/microphone
 * `ep_webrtc_err_SecureConnection`: Etherpad is not set up on a secure connection, which is requried for webrtc
 * `ep_webrtc_err_Unknown`: Some other unspecified error. Perhaps a bug in this plugin.
-* `ep_webrtc_err_Invalid`: Invalid error report. Either a bug in this plugin or a mischievous user.
 
 # Developing and contributing
 

--- a/index.js
+++ b/index.js
@@ -14,9 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+var log4js = require('ep_etherpad-lite/node_modules/log4js')
+var statsLogger = log4js.getLogger("stats");
 var eejs = require('ep_etherpad-lite/node/eejs/');
 var settings = require('ep_etherpad-lite/node/utils/Settings');
 var sessioninfos = require('ep_etherpad-lite/node/handler/PadMessageHandler').sessioninfos;
+var stats = require('ep_etherpad-lite/node/stats')
 var socketio;
 
 /**
@@ -58,6 +61,25 @@ function handleRTCMessage(client, payload)
   }
 }
 
+// Make sure any updates to this are reflected in README
+const statErrorNames = [
+  "Abort",
+  "Hardware",
+  "NotFound",
+  "NotSupported",
+  "Permission",
+  "SecureConnection",
+  "Unknown"
+]
+
+function handleErrorStatMessage(statName) {
+  if (statErrorNames.indexOf(statName) !== -1) {
+    stats.meter("ep_webrtc_err_" + statName).mark();
+  } else {
+    statsLogger.warn("Invalid ep_webrtc error stat: " + statName);
+  }
+}
+
 exports.clientVars = function(hook, context, callback)
 {
   var enabled = true;
@@ -88,6 +110,9 @@ exports.handleMessage = function ( hook, context, callback )
 {
   if (context.message.type == 'COLLABROOM' && context.message.data.type == 'RTC_MESSAGE') {
     handleRTCMessage(context.client, context.message.data.payload);
+    callback([null]);
+  } else if (context.message.type == 'STATS' && context.message.data.type == 'RTC_MESSAGE') {
+    handleErrorStatMessage(context.message.data.statName);
     callback([null]);
   } else {
     callback();

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -110,9 +110,11 @@ var rtc = (function() {
           reason = "Sorry, your browser does not support WebRTC. (or you have it disabled in your settings).<br><br>" +
               "To participate in this audio/video chat you have to user a browser with WebRTC support like Chrome, Firefox or Opera." +
               '<a href="http://www.webrtc.org/" target="_new">Find out more</a>'
+          self.sendErrorStat("NotSupported");
           break;
         case "CustomSecureConnectionError":
           reason = "Sorry, you need to install SSL certificates for your Etherpad instance to use WebRTC"
+          self.sendErrorStat("SecureConnection");
           break;
         case "NotAllowedError":
           // For certain (I suspect older) browsers, `NotAllowedError` indicates either an insecure connection or the user rejecting camera permissions.
@@ -120,24 +122,30 @@ var rtc = (function() {
           // (webrtc is considered secure for https connections or on localhost)
           if (location.protocol === "https:" || location.hostname === "localhost" || location.hostname === "127.0.0.1") {
             reason = "Sorry, you need to give us permission to use your camera and microphone"
+            self.sendErrorStat("Permission");
           } else {
             reason = "Sorry, you need to install SSL certificates for your Etherpad instance to use WebRTC"
+            self.sendErrorStat("SecureConnection");
           }
           break;
         case "NotFoundError":
-          reason = "Sorry, we couldnt't find a suitable camera on your device. If you have a camera, make sure it set up correctly and refresh this website to retry."
+          reason = "Sorry, we couldn't find a suitable camera on your device. If you have a camera, make sure it set up correctly and refresh this website to retry."
+          self.sendErrorStat("NotFound");
           break;
         case "NotReadableError":
           // `err.message` might give useful info to the user (not necessarily useful for other error messages)
           reason = "Sorry, a hardware error occurred that prevented access to your camera and/or microphone:<br><br>" + err.message
+          self.sendErrorStat("Hardware");
           break;
         case "AbortError":
           // `err.message` might give useful info to the user (not necessarily useful for other error messages)
           reason = "Sorry, an error occurred (probably not hardware related) that prevented access to your camera and/or microphone:<br><br>" + err.message
+          self.sendErrorStat("Abort");
           break;
         default:
           // `err` as a string might give useful info to the user (not necessarily useful for other error messages)
           reason = "Sorry, there was an unknown Error:<br><br>" + err
+          self.sendErrorStat("Unknown");
       }
       $.gritter.add({
         title: "Error",
@@ -313,6 +321,15 @@ var rtc = (function() {
         .append($disableVideo)
         .append($largeVideo)
         .insertAfter($video);
+    },
+    // Sends a stat to the back end. `statName` must be in the
+    // approved list on the server side.
+    sendErrorStat: function(statName) {
+      var msg = { "component" : "pad",
+                  "type": "STATS",
+                  "data": {statName: statName, type: 'RTC_MESSAGE'}
+      }
+      pad.socket.json.send(msg);
     },
     sendMessage: function(to, data) {
       self._pad.collabClient.sendMessage({


### PR DESCRIPTION
Initial suggestion was making the stats stats POST endpoint. The specific there didn't seem that important, and websockets seemed to be a bit more in line with how things work, so I went with that, but @JohnMcLear np if you specifically wanted POST here.