### PR TITLE
Fix tests again

### DIFF
--- a/static/tests/frontend/specs/checkbox.js
+++ b/static/tests/frontend/specs/checkbox.js
@@ -102,8 +102,8 @@ describe('test settingToCheckbox, which creates checkboxes that are linked to to
       expect(chrome$('#checkboxId6').prop('checked')).to.equal(false);
 
       // Confirm that the urlVars set the cookies
-      expect(chrome$.window.document.cookie.indexOf('cookie5%22%3Atrue')).to.not.equal(-1);
-      expect(chrome$.window.document.cookie.indexOf('cookie6%22%3Afalse')).to.not.equal(-1);
+      expect(chrome$.window.document.cookie.indexOf('cookie5%22:true')).to.not.equal(-1);
+      expect(chrome$.window.document.cookie.indexOf('cookie6%22:false')).to.not.equal(-1);
 
       chrome$('#checkboxId1').click();
       chrome$('#checkboxId2').click();
@@ -124,12 +124,12 @@ describe('test settingToCheckbox, which creates checkboxes that are linked to to
           chrome$('#checkboxId6').prop('checked') === true
         );
       }, 1000).done(() => {
-        expect(chrome$.window.document.cookie.indexOf('cookie1%22%3Afalse')).to.not.equal(-1);
-        expect(chrome$.window.document.cookie.indexOf('cookie2%22%3Atrue')).to.not.equal(-1);
-        expect(chrome$.window.document.cookie.indexOf('cookie3%22%3Afalse')).to.not.equal(-1);
-        expect(chrome$.window.document.cookie.indexOf('cookie4%22%3Atrue')).to.not.equal(-1);
-        expect(chrome$.window.document.cookie.indexOf('cookie5%22%3Afalse')).to.not.equal(-1);
-        expect(chrome$.window.document.cookie.indexOf('cookie6%22%3Atrue')).to.not.equal(-1);
+        expect(chrome$.window.document.cookie.indexOf('cookie1%22:false')).to.not.equal(-1);
+        expect(chrome$.window.document.cookie.indexOf('cookie2%22:true')).to.not.equal(-1);
+        expect(chrome$.window.document.cookie.indexOf('cookie3%22:false')).to.not.equal(-1);
+        expect(chrome$.window.document.cookie.indexOf('cookie4%22:true')).to.not.equal(-1);
+        expect(chrome$.window.document.cookie.indexOf('cookie5%22:false')).to.not.equal(-1);
+        expect(chrome$.window.document.cookie.indexOf('cookie6%22:true')).to.not.equal(-1);
         done();
       });
     });

--- a/static/tests/frontend/specs/enable_disable.js
+++ b/static/tests/frontend/specs/enable_disable.js
@@ -3,9 +3,12 @@
 
 describe('enable and disable webrtc', function () {
   context('WebRTC is disabled', function () {
-    before(async function () {
-      await helper.newPad({
+    before(function (done) {
+      helper.newPad({
         padPrefs: {rtcEnabled: false, fakeWebrtcFirefox: true},
+        cb: () => {
+          helper.waitFor(() => helper.padChrome$, 1000).done(done);
+        }
       });
       this.timeout(60000);
     });
@@ -25,9 +28,12 @@ describe('enable and disable webrtc', function () {
   });
 
   context('WebRTC is enabled', function () {
-    before(async function () {
-      await helper.newPad({
+    before(function (done) {
+      helper.newPad({
         padPrefs: {rtcEnabled: true, fakeWebrtcFirefox: true},
+        cb: () => {
+          helper.waitFor(() => helper.padChrome$, 1000).done(done);
+        }
       });
       this.timeout(60000);
     });

--- a/static/tests/frontend/specs/errors.js
+++ b/static/tests/frontend/specs/errors.js
@@ -2,13 +2,16 @@
 'use strict';
 
 describe('Test that we show the correct error messages when trying to start webrtc', function () {
-  before(async function () {
+  before(function (done) {
     // Make sure webrtc starts disabled so we have time to wrap getUserMedia
-    await helper.newPad({
+    helper.newPad({
       padPrefs: {
         rtcEnabled: true,
         fakeWebrtcFirefox: true,
       },
+      cb: () => {
+        helper.waitFor(() => helper.padChrome$, 1000).done(done);
+      }
     });
     this.timeout(60000);
   });

--- a/static/tests/frontend/specs/interface_buttons.js
+++ b/static/tests/frontend/specs/interface_buttons.js
@@ -63,19 +63,38 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
 
       this.timeout(60000);
 
-      expect(chrome$('video').css('width')).to.be('160px');
-      expect(chrome$('video').css('height')).to.be('116px');
+      // i.e., "160.25px" -> 160.25 the number
+      const num_from_css_size = (size) => {
+        expect(size.slice(-2)).to.be('px')
+        return Number(size.slice(0, -2))
+      }
+
+      // All of these sizes have to allow for tolerances.
+      // I.e. it has come back a quarter pixel off before.
+      const $video = chrome$('video')
+      expect(num_from_css_size($video.css('width'))).to.be.within(159, 161);
+      expect(num_from_css_size($video.css('height'))).to.be.within(115, 117);
 
       const $enlargeBtn = chrome$('.enlarge-btn');
       $enlargeBtn.click();
 
-      helper.waitFor(() => chrome$('video').css('width') === '260px' &&
-               chrome$('video').css('height') === '191px', 1000).done(() => {
+      // Expect it to grow to 260, 190
+      helper.waitFor(() =>
+        (
+          num_from_css_size($video.css('width')) > 259 &&
+          num_from_css_size($video.css('height')) > 190
+        ),
+        1000
+      ).done(() => {
         $enlargeBtn.click();
-        helper.waitFor(() => chrome$('video').css('width') === '160px' &&
-                 chrome$('video').css('height') === '116px', 1000).done(() => {
-          done();
-        });
+        // Expect it to shrink to 160, 116
+        helper.waitFor(() =>
+          (
+            num_from_css_size($video.css('width')) < 161 &&
+            num_from_css_size($video.css('height')) < 117
+          ),
+          1000
+        ).done(done)
       });
     });
 


### PR DESCRIPTION
Many cookie problems were already addressed by ether/etherpad-lite#4905, as of this writing still in PR. After that PR and this one, the tests work again on Firefox and Chrome, for me anyway.

Fixed here:

Some regressions from switching to async/await; `helper.chrome$` was not ready.

One issue with css size imprecision.

One issue with how for some reason cookies don't have `{:}` characters espaped, while they do have others escaped.