### PR TITLE
Pass `RTCIceCandidateInit` object directly to `addIceCandidate()`

### DIFF
--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -440,7 +440,7 @@ const rtc = (() => {
         payload: {data, to},
       });
     },
-    receiveMessage: (msg) => {
+    receiveMessage: async (msg) => {
       const peer = msg.from;
       const data = msg.data;
       const type = data.type;
@@ -500,15 +500,11 @@ const rtc = (() => {
           pc[peer].setRemoteDescription(answer, () => {}, logError);
         }
       } else if (type === 'icecandidate') {
-        if (pc[peer]) {
-          const candidate = new RTCIceCandidate(data.candidate);
-          const p = pc[peer].addIceCandidate(candidate);
-          if (p) {
-            p.then(() => {
-              // Do stuff when the candidate is successfully passed to the ICE agent
-            }).catch(() => {
-              console.log('Error: Failure during addIceCandidate()', data);
-            });
+        if (pc[peer] && data.candidate) {
+          try {
+            await pc[peer].addIceCandidate(data.candidate);
+          } catch (err) {
+            console.error('Failed to add ICE candidate:', err);
           }
         }
       } else {


### PR DESCRIPTION
The intermediate `RTCIceCandidate` object is unnecessary and seems to cause the following error on Chrome 68 (released ~2.5 years ago) when the end-of-candidates signal arrives:

    Error: Failed to construct 'RTCIceCandidate': The 'candidate'
    property is not a string, or is empty.
        at new RTCIceCandidate
        at Object.receiveMessage
        at Object.handleClientMessage_RTC_MESSAGE [as hook_fn]
        at callHookFnSync
        at hooks.map
        at Array.map
        at Object.exports.callAll
        at Object.handleMessageFromServer
        at r.socket.on
        at r.emit

cc @packardone 