### PR TITLE
Fix handling of `notify` arg to `hangup()`

### DIFF
--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -441,9 +441,7 @@ const rtc = (() => {
       });
     },
     getUserId: () => self._pad.getUserId(),
-    hangup: (...args) => {
-      const userId = args[0];
-      const notify = args[1] || true;
+    hangup: (userId, notify = true) => {
       if (!pc[userId]) return;
       self.setStream(userId, null);
       pc[userId].close();


### PR DESCRIPTION
This fixes a bug affecting versions v0.1.11 to v0.1.26 (inclusive) introduced in commit 62b1ce8e28bef49bd6b31cbd6405bd0385719a26.