### PR TITLE
Improve error handling

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -6,7 +6,6 @@
     "pad.ep_webrtc.error.notFound": "Failed to find a camera and/or microphone. Reload the page to retry.",
     "pad.ep_webrtc.error.notReadable": "Sorry, a hardware error occurred that prevented access to your camera and/or microphone:",
     "pad.ep_webrtc.error.otherCantAccess": "Sorry, the browser doesn't have access to your camera and/or microphone. Please check permissions in your browser's settings. This is most likely not a hardware error:",
-    "pad.ep_webrtc.error.other": "Sorry, there was an unknown error:",
 
     "pad.settings.audioenabledonstart": "Audio ON at Start",
     "pad.settings.videoenabledonstart": "Video ON at Start"

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,9 +1,9 @@
 {
     "pad.settings.enablertc": "Enable Audio/Video Chat",
 
-    "pad.ep_webrtc.error.ssl": "Sorry, you need to install SSL certificates for your Etherpad instance to use WebRTC.",
-    "pad.ep_webrtc.error.permission": "Sorry, you need to give us permission to use your camera and microphone.",
-    "pad.ep_webrtc.error.notFound": "Sorry, we couldn't find a suitable camera on your device. If you have a camera, make sure it set up correctly and refresh this website to retry.",
+    "pad.ep_webrtc.error.ssl": "TLS (https) is required to use WebRTC.",
+    "pad.ep_webrtc.error.permission": "Failed to get permission to access your camera or microphone.",
+    "pad.ep_webrtc.error.notFound": "Failed to find a camera and/or microphone. Reload the page to retry.",
     "pad.ep_webrtc.error.notReadable": "Sorry, a hardware error occurred that prevented access to your camera and/or microphone:",
     "pad.ep_webrtc.error.otherCantAccess": "Sorry, the browser doesn't have access to your camera and/or microphone. Please check permissions in your browser's settings. This is most likely not a hardware error:",
     "pad.ep_webrtc.error.other": "Sorry, there was an unknown error:",

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -347,31 +347,13 @@ const rtc = (() => {
         if (localStream && !pc[peer].getSenders().length) {
           for (const track of localStream.getTracks()) pc[peer].addTrack(track, localStream);
         }
-        try {
-          await pc[peer].setRemoteDescription(data.offer);
-          await pc[peer].setLocalDescription();
-          self.sendMessage(peer, {type: 'answer', answer: pc[peer].localDescription});
-        } catch (err) {
-          logError(err);
-          return;
-        }
+        await pc[peer].setRemoteDescription(data.offer);
+        await pc[peer].setLocalDescription();
+        self.sendMessage(peer, {type: 'answer', answer: pc[peer].localDescription});
       } else if (type === 'answer') {
-        if (pc[peer]) {
-          try {
-            await pc[peer].setRemoteDescription(data.answer);
-          } catch (err) {
-            logError(err);
-            return;
-          }
-        }
+        if (pc[peer]) await pc[peer].setRemoteDescription(data.answer);
       } else if (type === 'icecandidate') {
-        if (pc[peer] && data.candidate) {
-          try {
-            await pc[peer].addIceCandidate(data.candidate);
-          } catch (err) {
-            console.error('Failed to add ICE candidate:', err);
-          }
-        }
+        if (pc[peer] && data.candidate) await pc[peer].addIceCandidate(data.candidate);
       } else {
         console.log('unknown message', data);
       }
@@ -395,13 +377,8 @@ const rtc = (() => {
         self.createPeerConnection(userId);
       }
       for (const track of localStream.getTracks()) pc[userId].addTrack(track, localStream);
-      try {
-        await pc[userId].setLocalDescription();
-        self.sendMessage(userId, {type: 'offer', offer: pc[userId].localDescription});
-      } catch (err) {
-        logError(err);
-        return;
-      }
+      await pc[userId].setLocalDescription();
+      self.sendMessage(userId, {type: 'offer', offer: pc[userId].localDescription});
     },
     createPeerConnection: (userId) => {
       if (pc[userId]) {
@@ -576,8 +553,6 @@ const rtc = (() => {
       }
     },
   };
-
-  const logError = (error) => console.log('WebRTC ERROR:', error);
 
   self.pc = pc;
   return self;

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -154,7 +154,11 @@ const rtc = (() => {
       try {
         stream = await window.navigator.mediaDevices.getUserMedia(constraints);
       } catch (err) {
-        self.showUserMediaError(err);
+        try {
+          self.showUserMediaError(err);
+        } finally {
+          self.deactivate();
+        }
         return;
       }
       // Disable audio and/or video according to user/site settings.

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -554,6 +554,7 @@ const rtc = (() => {
           self.hangupAll();
         });
       }
+      $('#rtcbox').data('initialized', true); // Help tests determine when init() is done.
     },
   };
 

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -80,9 +80,6 @@ const rtc = (() => {
       return [null];
     },
     // END OF API HOOKS
-    show: () => {
-      $('#rtcbox').css('display', 'flex');
-    },
     showUserMediaError: (err) => { // show an error returned from getUserMedia
       let reason;
       // For reference on standard errors returned by getUserMedia:
@@ -138,15 +135,11 @@ const rtc = (() => {
         sticky: true,
         class_name: 'error',
       });
-      self.hide();
-    },
-    hide: () => {
-      $('#rtcbox').hide();
     },
     activate: async () => {
       $('#options-enablertc').prop('checked', true);
       if (isActive) return;
-      self.show();
+      $('#rtcbox').css('display', 'flex');
       padcookie.setPref('rtcEnabled', true);
       isActive = true;
       await self.getUserMedia();
@@ -154,7 +147,7 @@ const rtc = (() => {
     deactivate: () => {
       $('#options-enablertc').prop('checked', false);
       if (!isActive) return;
-      self.hide();
+      $('#rtcbox').hide();
       padcookie.setPref('rtcEnabled', false);
       self.hangupAll();
       if (localStream) {

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -150,32 +150,34 @@ const rtc = (() => {
         // --use-fake-device-for-media-stream
         constraints.fake = true;
       }
+      let stream;
       try {
-        const stream = await window.navigator.mediaDevices.getUserMedia(constraints);
-        // Disable audio and/or video according to user/site settings.
-        // Do this before setting `localStream` to avoid a race condition
-        // that might flash the video on for an instant before disabling it.
-        const audioTrack = stream.getAudioTracks()[0];
-        // using `.prop("checked") === true` to make absolutely sure the result is a boolean
-        // we don't want bugs when it comes to muting/turning off video
-        if (audioTrack) {
-          audioTrack.enabled = $('#options-audioenabledonstart').prop('checked') === true;
-        }
-        const videoTrack = stream.getVideoTracks()[0];
-        if (videoTrack) {
-          videoTrack.enabled = $('#options-videoenabledonstart').prop('checked') === true;
-        }
-
-        localStream = stream;
-        self.setStream(self._pad.getUserId(), stream);
-        self._pad.collabClient.getConnectedUsers().forEach((user) => {
-          if (user.userId === self.getUserId()) return;
-          if (pc[user.userId]) self.hangup(user.userId);
-          self.call(user.userId);
-        });
+        stream = await window.navigator.mediaDevices.getUserMedia(constraints);
       } catch (err) {
         self.showUserMediaError(err);
+        return;
       }
+      // Disable audio and/or video according to user/site settings.
+      // Do this before setting `localStream` to avoid a race condition
+      // that might flash the video on for an instant before disabling it.
+      const audioTrack = stream.getAudioTracks()[0];
+      // using `.prop("checked") === true` to make absolutely sure the result is a boolean
+      // we don't want bugs when it comes to muting/turning off video
+      if (audioTrack) {
+        audioTrack.enabled = $('#options-audioenabledonstart').prop('checked') === true;
+      }
+      const videoTrack = stream.getVideoTracks()[0];
+      if (videoTrack) {
+        videoTrack.enabled = $('#options-videoenabledonstart').prop('checked') === true;
+      }
+
+      localStream = stream;
+      self.setStream(self._pad.getUserId(), stream);
+      self._pad.collabClient.getConnectedUsers().forEach((user) => {
+        if (user.userId === self.getUserId()) return;
+        if (pc[user.userId]) self.hangup(user.userId);
+        self.call(user.userId);
+      });
     },
     deactivate: () => {
       $('#options-enablertc').prop('checked', false);

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -122,12 +122,8 @@ const rtc = (() => {
           self.sendErrorStat('Abort');
           break;
         default:
-          // `err` as a string might give useful info to the user
-          // (not necessarily useful for other error messages)
-          reason = $('<div>')
-              .append($('<p>').text(html10n.get('pad.ep_webrtc.error.other')))
-              .append($('<p>').text(err));
-          self.sendErrorStat('Unknown');
+          // Let Etherpad's error handling handle the error.
+          throw err;
       }
       $.gritter.add({
         title: 'Error',

--- a/static/tests/frontend/specs/errors.js
+++ b/static/tests/frontend/specs/errors.js
@@ -63,8 +63,4 @@ describe('Test that we show the correct error messages when trying to start webr
   it('gives the right error message for AbortError', function (done) {
     tryError('AbortError', 'not a hardware error', done);
   });
-
-  it('gives the right error message for an unknown error', function (done) {
-    tryError('asdf', 'there was an unknown error', done);
-  });
 });

--- a/static/tests/frontend/specs/errors.js
+++ b/static/tests/frontend/specs/errors.js
@@ -1,66 +1,53 @@
 'use strict';
 
-describe('Test that we show the correct error messages when trying to start webrtc', function () {
-  before(function (done) {
-    // Make sure webrtc starts disabled so we have time to wrap getUserMedia
-    helper.newPad({
-      padPrefs: {
-        rtcEnabled: true,
-        fakeWebrtcFirefox: true,
-      },
-      cb: () => {
-        helper.waitFor(() => helper.padChrome$, 1000).done(done);
-      },
-    });
+describe('error handling', function () {
+  let enable;
+  let chrome$;
+  let getUserMediaBackup;
+
+  const testCases = [
+    // Hard to test the version of NotAllowedError that is the SSL error
+    // because it requires changing window.location
+    ['NotAllowedError', 'Failed to get permission to access'],
+    ['NotFoundError', 'Failed to find a camera'],
+    ['NotReadableError', 'hardware error occurred'],
+    ['AbortError', 'not a hardware error'],
+  ];
+
+  before(async function () {
     this.timeout(60000);
+    await helper.aNewPad({
+      padPrefs: {fakeWebrtcFirefox: true, rtcEnabled: false},
+    });
+    chrome$ = helper.padChrome$;
+    await helper.waitForPromise(() => chrome$('#rtcbox').data('initialized'));
+    enable = chrome$('#options-enablertc');
+    getUserMediaBackup = chrome$.window.navigator.mediaDevices.getUserMedia;
   });
 
-  beforeEach(function (done) {
-    const chrome$ = helper.padChrome$;
+  after(async function () {
+    chrome$.window.navigator.mediaDevices.getUserMedia = getUserMediaBackup;
+  });
+
+  beforeEach(async function () {
     // No idea why but this needs to be called twice to actually make #gritter-container hidden
     chrome$.gritter.removeAll({fade: false});
     chrome$.gritter.removeAll({fade: false});
-    done();
+    expect(enable.prop('checked')).to.equal(false);
   });
 
-  function tryError(errName, checkString, done) {
-    const chrome$ = helper.padChrome$;
-
-    chrome$.window.navigator.mediaDevices.getUserMedia = function () {
-      return new Promise(((resolve, reject) => {
-        const err = Error();
+  for (const [errName, checkString] of testCases) {
+    it(errName, async function () {
+      chrome$.window.navigator.mediaDevices.getUserMedia = async () => {
+        const err = new Error();
         err.name = errName;
-        reject(err);
-      }));
-    };
-
-    helper.waitFor(() => chrome$('#gritter-container:visible').length === 0, 1000).done(() => {
-      // a wrapper of the above, which includes displaying errors
-      chrome$.window.ep_webrtc.getUserMedia();
-
-      helper.waitFor(() => chrome$('#gritter-container:visible').length === 1, 1000).done(() => {
-        expect(chrome$('.gritter-title').html()).to.be('Error');
-        expect(chrome$('.gritter-content p').html()).to.contain(checkString);
-        done();
-      });
+        throw err;
+      };
+      await helper.waitForPromise(() => chrome$('#gritter-container:visible').length === 0, 1000);
+      enable.click();
+      await helper.waitForPromise(() => chrome$('#gritter-container:visible').length === 1, 1000);
+      expect(chrome$('.gritter-title').html()).to.be('Error');
+      expect(chrome$('.gritter-content p').html()).to.contain(checkString);
     });
   }
-
-  it('gives the right error message for NotAllowedError', function (done) {
-    // Hard to test the version of NotAllowedError that is the SSL error
-    // because it requires changing window.location
-    tryError('NotAllowedError', 'Failed to get permission to access', done);
-  });
-
-  it('gives the right error message for NotFoundError', function (done) {
-    tryError('NotFoundError', 'Failed to find a camera', done);
-  });
-
-  it('gives the right error message for NotReadableError', function (done) {
-    tryError('NotReadableError', 'hardware error occurred', done);
-  });
-
-  it('gives the right error message for AbortError', function (done) {
-    tryError('AbortError', 'not a hardware error', done);
-  });
 });

--- a/static/tests/frontend/specs/errors.js
+++ b/static/tests/frontend/specs/errors.js
@@ -49,11 +49,11 @@ describe('Test that we show the correct error messages when trying to start webr
   it('gives the right error message for NotAllowedError', function (done) {
     // Hard to test the version of NotAllowedError that is the SSL error
     // because it requires changing window.location
-    tryError('NotAllowedError', 'need to give us permission', done);
+    tryError('NotAllowedError', 'Failed to get permission to access', done);
   });
 
   it('gives the right error message for NotFoundError', function (done) {
-    tryError('NotFoundError', "couldn't find a suitable camera", done);
+    tryError('NotFoundError', 'Failed to find a camera', done);
   });
 
   it('gives the right error message for NotReadableError', function (done) {


### PR DESCRIPTION
Multiple commits:
* Reword error messages
* Don't hide the WebRTC box on error
* Let Etherpad's error handling handle unknown errors
* Don't swallow RTCPeerConnection errors
* Merge `getUserMedia()` into `activate()`
* Only call `showUserMediaError()` for `getUserMedia()` errors
* Leave deactivated if `getUserMedia()` fails
* tests: Redo `errors.js` tests

cc @packardone 