### PR TITLE
Always enable when URL has `av=YES`, even if disabled by cookie

### DIFF
--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -527,9 +527,7 @@ const rtc = (() => {
       if (typeof rtcEnabled === 'undefined') {
         rtcEnabled = $('#options-enablertc').prop('checked');
       }
-
-      // if a URL Parameter is set then activate
-      if (self.avInURL()) self.activate();
+      if (self.avInURL()) rtcEnabled = true;
 
       if (clientVars.webrtc.listenClass) {
         $(clientVars.webrtc.listenClass).on('click', () => {


### PR DESCRIPTION
FYI @packardone: The bug this PR fixes does not exist in your production version due to the way https://github.com/26llc/ep_webrtc/commit/5e8dcf4e14eeaa75fb16fa410ce4c40fa5a80bff was written.