### PR TITLE
Fix handling of peer name/color updates

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -13,7 +13,7 @@
       },
       "client_hooks": {
         "postAceInit": "ep_webrtc/static/js/webrtc:rtc.postAceInit",
-        "aceSetAuthorStyle": "ep_webrtc/static/js/webrtc:rtc.aceSetAuthorStyle",
+        "userJoinOrUpdate": "ep_webrtc/static/js/webrtc:rtc.userJoinOrUpdate",
         "userLeave": "ep_webrtc/static/js/webrtc:rtc.userLeave",
         "handleClientMessage_RTC_MESSAGE": "ep_webrtc/static/js/webrtc:rtc.handleClientMessage_RTC_MESSAGE"
       }

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -221,9 +221,8 @@ const rtc = (() => {
       const videoId = `video_${userId.replace(/\./g, '_')}`;
       let video = $(`#${videoId}`)[0];
 
-      const user = self.getUserFromId(userId);
-
       if (!video && stream) {
+        const user = self.getUserFromId(userId);
         const size = videoSizes.small;
         const videoContainer = $("<div class='video-container'>")
             .css({'width': size, 'max-height': size})

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -64,10 +64,11 @@ const rtc = (() => {
     setUrlParamString: (str) => {
       urlParamString = str;
     },
-    aceSetAuthorStyle: (hookName, {author}) => {
-      if (!author) return;
-      self.updatePeerNameAndColor(author);
+
+    userJoinOrUpdate: (hookName, {userInfo}) => {
+      self.updatePeerNameAndColor(userInfo);
     },
+
     userLeave: (hookName, {userInfo: {userId}}) => {
       self.hangup(userId, false);
     },
@@ -77,9 +78,9 @@ const rtc = (() => {
     },
     // END OF API HOOKS
 
-    updatePeerNameAndColor: (userId) => {
-      const {name = html10n.get('pad.userlist.unnamed'), colorId = 0} =
-          self.getUserFromId(userId) || {};
+    updatePeerNameAndColor: (userInfo) => {
+      if (!userInfo) return;
+      const {userId, name = html10n.get('pad.userlist.unnamed'), colorId = 0} = userInfo;
       const color = typeof colorId === 'number' ? clientVars.colorPalette[colorId] : colorId;
       $(`#video_${userId.replace(/\./g, '_')}`)
           .css({'border-color': color})
@@ -246,7 +247,7 @@ const rtc = (() => {
           video.muted = true;
         }
         self.addInterface(userId, stream);
-        self.updatePeerNameAndColor(userId);
+        self.updatePeerNameAndColor(self.getUserFromId(userId));
       }
       if (stream) {
         video.srcObject = stream;

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -68,11 +68,11 @@ const rtc = (() => {
       if (!author) return;
       const user = self.getUserFromId(author);
       if (!user) return;
-      const color =
-          typeof user.colorId === 'number' ? clientVars.colorPalette[user.colorId] : user.colorId;
+      const {name = html10n.get('pad.userlist.unnamed'), colorId = 0} = user;
+      const color = typeof colorId === 'number' ? clientVars.colorPalette[colorId] : colorId;
       $(`#video_${author.replace(/\./g, '_')}`)
           .css({'border-color': color})
-          .siblings('.user-name').text(user.name);
+          .siblings('.user-name').text(name);
     },
     userLeave: (hookName, {userInfo: {userId}}) => {
       self.hangup(userId, false);
@@ -224,15 +224,15 @@ const rtc = (() => {
       let video = $(`#${videoId}`)[0];
 
       if (!video && stream) {
-        const user = self.getUserFromId(userId);
-        const color =
-            typeof user.colorId === 'number' ? clientVars.colorPalette[user.colorId] : user.colorId;
+        const {name = html10n.get('pad.userlist.unnamed'), colorId = 0} =
+            self.getUserFromId(userId) || {};
+        const color = typeof colorId === 'number' ? clientVars.colorPalette[colorId] : colorId;
         const size = videoSizes.small;
         const videoContainer = $("<div class='video-container'>")
             .css({'width': size, 'max-height': size})
             .appendTo($('#rtcbox'));
 
-        videoContainer.append($('<div class="user-name">').text(user.name));
+        videoContainer.append($('<div class="user-name">').text(name));
 
         video = $('<video playsinline>')
             .attr('id', videoId)

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -68,8 +68,10 @@ const rtc = (() => {
       if (!author) return;
       const user = self.getUserFromId(author);
       if (!user) return;
+      const color =
+          typeof user.colorId === 'number' ? clientVars.colorPalette[user.colorId] : user.colorId;
       $(`#video_${author.replace(/\./g, '_')}`)
-          .css({'border-color': user.colorId})
+          .css({'border-color': color})
           .siblings('.user-name').text(user.name);
     },
     userLeave: (hookName, {userInfo: {userId}}) => {
@@ -223,6 +225,8 @@ const rtc = (() => {
 
       if (!video && stream) {
         const user = self.getUserFromId(userId);
+        const color =
+            typeof user.colorId === 'number' ? clientVars.colorPalette[user.colorId] : user.colorId;
         const size = videoSizes.small;
         const videoContainer = $("<div class='video-container'>")
             .css({'width': size, 'max-height': size})
@@ -232,7 +236,7 @@ const rtc = (() => {
 
         video = $('<video playsinline>')
             .attr('id', videoId)
-            .css({'border-color': user.colorId, 'width': size, 'max-height': size})
+            .css({'border-color': color, 'width': size, 'max-height': size})
             .appendTo(videoContainer)[0];
 
         video.autoplay = true;


### PR DESCRIPTION
Multiple commits:
* Avoid unnecessary calls to `getUserFromId()`
* Convert color ID to color
* Gracefully handle missing peer name or color
* Factor out duplicate code to set peer name and color
* Use `userJoinOrUpdate` instead of `aceSetAuthorStyle`

Fixing name/color updates is not urgent, but it makes it easier to fix the tests.

cc @packardone 