### PR TITLE
Minor fixes

### DIFF
--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -252,7 +252,8 @@ const rtc = (() => {
         self.updatePeerNameAndColor(self.getUserFromId(userId));
       }
       if (stream) {
-        video.srcObject = stream;
+        // Avoid flicker by checking if .srcObject already equals stream.
+        if (video.srcObject !== stream) video.srcObject = stream;
       } else if (video) {
         $(video).parent().remove();
       }

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -157,16 +157,18 @@ const rtc = (() => {
         // --use-fake-device-for-media-stream
         constraints.fake = true;
       }
-      let stream;
-      try {
-        stream = await window.navigator.mediaDevices.getUserMedia(constraints);
-      } catch (err) {
+      let stream = new MediaStream();
+      if (constraints.audio || constraints.video) {
         try {
-          self.showUserMediaError(err);
-        } finally {
-          self.deactivate();
+          stream = await window.navigator.mediaDevices.getUserMedia(constraints);
+        } catch (err) {
+          try {
+            self.showUserMediaError(err);
+          } finally {
+            self.deactivate();
+          }
+          return;
         }
-        return;
       }
       // Disable audio and/or video according to user/site settings.
       // Do this before setting `localStream` to avoid a race condition


### PR DESCRIPTION
Multiple commits:
* Don't call `getUserMedia()` if both audio and video disabled
* Avoid flicker if the stream hasn't changed

The former is a prereq to fixing tests.

cc @packardone 