### PR TITLE
Various minor cleanups and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ clients. See STUN/TURN in settings.
 There's a setting for each user under their settings menu that can turn
 audio/video chat feature off and on. The setting is saved in cookies and will
 apply when they reload the page. The user can also change the value of this
-setting to true by loading the page with `?av=YES` in the URL path (at the
-moment, `av=NO` does not work to turn it off).
+setting by adding `av=true` or `av=false` to the URL query parameters.
 
 ### Site-Wide
 

--- a/index.js
+++ b/index.js
@@ -117,7 +117,6 @@ exports.setSocketIO = (hookName, {io}) => { socketio = io; };
 
 exports.eejsBlock_mySettings = (hookName, context) => {
   context.content += eejs.require('./templates/settings.ejs', {
-    enabled: settings.enabled,
     audio_hard_disabled: settings.audio.disabled === 'hard',
     video_hard_disabled: settings.video.disabled === 'hard',
   }, module);

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ exports.setSocketIO = (hookName, {io}) => { socketio = io; };
 
 exports.eejsBlock_mySettings = (hookName, context) => {
   context.content += eejs.require('./templates/settings.ejs', {
-    enabled: settings.enabled ? 'checked' : 'unchecked',
+    enabled: settings.enabled,
     audio_hard_disabled: settings.audio.disabled === 'hard',
     video_hard_disabled: settings.video.disabled === 'hard',
   }, module);

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -223,26 +223,7 @@ exports.rtc = new class {
       return;
     }
     if ($video.length === 0) {
-      const isLocal = userId === this.getUserId();
-      const size = `${this._settings.video.sizes.small}px`;
-      $video = $('<video>')
-          .attr({
-            id: videoId,
-            playsinline: '',
-            autoplay: '',
-            muted: isLocal ? '' : null,
-          })
-          .prop('muted', isLocal) // Setting the 'muted' attribute isn't sufficient for some reason.
-          .css({'width': size, 'max-height': size});
-      $('#rtcbox').append(
-          $('<div>')
-              .addClass('video-container')
-              .toggleClass('local-user', isLocal)
-              .css({'width': size, 'max-height': size})
-              .append($('<div>').addClass('user-name'))
-              .append($video));
-      this.addInterface(userId, stream);
-      this.updatePeerNameAndColor(this.getUserFromId(userId));
+      $video = this.addInterface(userId, stream);
     }
     // Avoid flicker by checking if .srcObject already equals stream.
     if ($video[0].srcObject !== stream) $video[0].srcObject = stream;
@@ -251,12 +232,28 @@ exports.rtc = new class {
   addInterface(userId, stream) {
     const isLocal = userId === this.getUserId();
     const videoId = `video_${userId.replace(/\./g, '_')}`;
-    const $video = $(`#${videoId}`);
-
+    const size = `${this._settings.video.sizes.small}px`;
+    const $video = $('<video>')
+        .attr({
+          id: videoId,
+          playsinline: '',
+          autoplay: '',
+          muted: isLocal ? '' : null,
+        })
+        .prop('muted', isLocal) // Setting the 'muted' attribute isn't sufficient for some reason.
+        .css({'width': size, 'max-height': size});
     const $interface = $('<div>')
         .addClass('interface-container')
-        .attr('id', `interface_${videoId}`)
-        .insertAfter($video);
+        .attr('id', `interface_${videoId}`);
+    $('#rtcbox').append(
+        $('<div>')
+            .addClass('video-container')
+            .toggleClass('local-user', isLocal)
+            .css({'width': size, 'max-height': size})
+            .append($('<div>').addClass('user-name'))
+            .append($video)
+            .append($interface));
+    this.updatePeerNameAndColor(this.getUserFromId(userId));
 
     // /////
     // Mute button
@@ -325,6 +322,8 @@ exports.rtc = new class {
             $video.css({'width': videoSize, 'max-height': videoSize});
           },
         }));
+
+    return $video;
   }
 
   // Sends a stat to the back end. `statName` must be in the

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -542,11 +542,7 @@ exports.rtc = new class {
         this.deactivate();
       }
     });
-    if (this._isActive) {
-      $(window).on('unload', () => {
-        this.hangupAll();
-      });
-    }
+    $(window).on('unload', () => { this.hangupAll(); });
     if (rtcEnabled) {
       await this.activate();
     } else {

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -477,7 +477,7 @@ exports.rtc = new class {
     if (['YES', 'true'].includes(urlValue)) { // 'YES' is for backward compatibility with av=YES.
       padcookie.setPref(params.cookie, true);
       value = true;
-    } else if (urlValue === 'false') {
+    } else if (['NO', 'false'].includes(urlValue)) { // 'NO' for symmetry with deprecated av=YES.
       padcookie.setPref(params.cookie, false);
       value = false;
     } else {

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -253,62 +253,57 @@ exports.rtc = new class {
     const videoId = `video_${userId.replace(/\./g, '_')}`;
     const $video = $(`#${videoId}`);
 
+    const $interface = $('<div>')
+        .addClass('interface-container')
+        .attr('id', `interface_${videoId}`)
+        .insertAfter($video);
+
     // /////
     // Mute button
     // /////
 
     const audioHardDisabled = this._settings.audio.disabled === 'hard';
     const hasAudio = stream.getAudioTracks().some((t) => t.enabled);
-    const $mute = $("<span class='interface-btn audio-btn buttonicon'>")
+    $interface.append($('<span>')
+        .addClass('interface-btn audio-btn buttonicon')
         .attr('title',
             audioHardDisabled ? 'Audio disallowed by admin'
             : hasAudio ? 'Mute'
             : 'Unmute')
         .toggleClass('muted', !hasAudio || audioHardDisabled)
-        .toggleClass('disallowed', audioHardDisabled);
-
-    if (!audioHardDisabled) {
-      $mute.on({
-        click: (event) => {
-          let muted;
-          if (isLocal) {
-            muted = this.toggleMuted();
-          } else {
-            $video[0].muted = !$video[0].muted;
-            muted = $video[0].muted;
-          }
-          $mute
-              .attr('title', muted ? 'Unmute' : 'Mute')
-              .toggleClass('muted', muted);
-        },
-      });
-    }
+        .toggleClass('disallowed', audioHardDisabled)
+        .on(audioHardDisabled ? {} : {
+          click: (event) => {
+            const muted = isLocal ? this.toggleMuted() : ($video[0].muted = !$video[0].muted);
+            $(event.currentTarget)
+                .attr('title', muted ? 'Unmute' : 'Mute')
+                .toggleClass('muted', muted);
+          },
+        }));
 
     // /////
     // Disable Video button
     // /////
 
-    let $disableVideo = null;
     if (isLocal) {
       const videoHardDisabled = this._settings.video.disabled === 'hard';
       const hasVideo = stream.getVideoTracks().some((t) => t.enabled);
-      $disableVideo = $("<span class='interface-btn video-btn buttonicon'>")
+      $interface.append($('<span>')
+          .addClass('interface-btn video-btn buttonicon')
           .attr('title',
               videoHardDisabled ? 'Video disallowed by admin'
               : hasVideo ? 'Disable video'
               : 'Enable video')
           .toggleClass('off', !hasVideo || videoHardDisabled)
-          .toggleClass('disallowed', videoHardDisabled);
-      if (!videoHardDisabled) {
-        $disableVideo.on({
-          click: (event) => {
-            const videoEnabled = !this.toggleVideo();
-            $disableVideo
-                .attr('title', videoEnabled ? 'Disable video' : 'Enable video')
-                .toggleClass('off', !videoEnabled);
-          },
-        });
-      }
+          .toggleClass('disallowed', videoHardDisabled)
+          .on(videoHardDisabled ? {} : {
+            click: (event) => {
+              const videoEnabled = !this.toggleVideo();
+              $(event.currentTarget)
+                  .attr('title', videoEnabled ? 'Disable video' : 'Enable video')
+                  .toggleClass('off', !videoEnabled);
+            },
+          }));
     }
 
     // /////
@@ -316,31 +311,20 @@ exports.rtc = new class {
     // /////
 
     let videoEnlarged = false;
-    const $largeVideo = $("<span class='interface-btn enlarge-btn buttonicon'>")
+    $interface.append($('<span>')
+        .addClass('interface-btn enlarge-btn buttonicon')
         .attr('title', 'Make video larger')
         .on({
           click: (event) => {
             videoEnlarged = !videoEnlarged;
-            $largeVideo
+            $(event.currentTarget)
                 .attr('title', videoEnlarged ? 'Make video smaller' : 'Make video larger')
                 .toggleClass('large', videoEnlarged);
             const videoSize = `${this._settings.video.sizes[videoEnlarged ? 'large' : 'small']}px`;
             $video.parent().css({'width': videoSize, 'max-height': videoSize});
             $video.css({'width': videoSize, 'max-height': videoSize});
           },
-        });
-
-
-    // /////
-    // Combining
-    // /////
-
-    $("<div class='interface-container'>")
-        .attr('id', `interface_${videoId}`)
-        .append($mute)
-        .append($disableVideo)
-        .append($largeVideo)
-        .insertAfter($video);
+        }));
   }
 
   // Sends a stat to the back end. `statName` must be in the

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -160,14 +160,12 @@ exports.rtc = new class {
     // Do this before setting `this._localStream` to avoid a race condition
     // that might flash the video on for an instant before disabling it.
     const audioTrack = stream.getAudioTracks()[0];
-    // using `.prop("checked") === true` to make absolutely sure the result is a boolean
-    // we don't want bugs when it comes to muting/turning off video
     if (audioTrack) {
-      audioTrack.enabled = $('#options-audioenabledonstart').prop('checked') === true;
+      audioTrack.enabled = !!$('#options-audioenabledonstart').prop('checked');
     }
     const videoTrack = stream.getVideoTracks()[0];
     if (videoTrack) {
-      videoTrack.enabled = $('#options-videoenabledonstart').prop('checked') === true;
+      videoTrack.enabled = !!$('#options-videoenabledonstart').prop('checked');
     }
 
     this._localStream = stream;

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -457,7 +457,7 @@ exports.rtc = new class {
   }
 
   avInURL() {
-    return window.location.search.includes('av=YES');
+    return (new URLSearchParams(window.location.search)).get('av') === 'YES';
   }
 
   // Connect a setting to a checkbox. To be called on initialization.
@@ -472,15 +472,16 @@ exports.rtc = new class {
     }
 
     let value;
+    const urlValue = (new URLSearchParams(window.location.search)).get(params.urlVar);
 
     // * If the setting is in the URL: use it, and also set the cookie
     // * If the setting is not in the URL: try to get it from the cookie
     // * If the setting was in neither, go with the site-wide default value
     //   but don't put it in the cookies
-    if (window.location.search.includes(`${params.urlVar}=true`)) {
+    if (urlValue === 'true') {
       padcookie.setPref(params.cookie, true);
       value = true;
-    } else if (window.location.search.includes(`${params.urlVar}=false`)) {
+    } else if (urlValue === 'false') {
       padcookie.setPref(params.cookie, false);
       value = false;
     } else {

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -177,9 +177,9 @@ exports.rtc = new class {
 
     this._localStream = stream;
     this.setStream(this._pad.getUserId(), stream);
+    this.hangupAll();
     await Promise.all(this._pad.collabClient.getConnectedUsers().map(async (user) => {
       if (user.userId === this.getUserId()) return;
-      if (this._pc[user.userId]) this.hangup(user.userId);
       await this.call(user.userId);
     }));
   }

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -216,37 +216,36 @@ exports.rtc = new class {
   }
 
   setStream(userId, stream) {
-    const isLocal = userId === this.getUserId();
     const videoId = `video_${userId.replace(/\./g, '_')}`;
-    let video = $(`#${videoId}`)[0];
-
-    if (!video && stream) {
+    let $video = $(`#${videoId}`);
+    if (!stream) {
+      $video.parent().remove();
+      return;
+    }
+    if ($video.length === 0) {
+      const isLocal = userId === this.getUserId();
       const size = `${this._settings.video.sizes.small}px`;
-      const videoContainer = $("<div class='video-container'>")
-          .css({'width': size, 'max-height': size})
-          .appendTo($('#rtcbox'));
-
-      videoContainer.append($('<div class="user-name">'));
-
-      video = $('<video playsinline>')
-          .attr('id', videoId)
-          .css({'width': size, 'max-height': size})
-          .appendTo(videoContainer)[0];
-
-      video.autoplay = true;
-      if (isLocal) {
-        videoContainer.addClass('local-user');
-        video.muted = true;
-      }
+      $video = $('<video>')
+          .attr({
+            id: videoId,
+            playsinline: '',
+            autoplay: '',
+            muted: isLocal ? '' : null,
+          })
+          .prop('muted', isLocal) // Setting the 'muted' attribute isn't sufficient for some reason.
+          .css({'width': size, 'max-height': size});
+      $('#rtcbox').append(
+          $('<div>')
+              .addClass('video-container')
+              .toggleClass('local-user', isLocal)
+              .css({'width': size, 'max-height': size})
+              .append($('<div>').addClass('user-name'))
+              .append($video));
       this.addInterface(userId, stream);
       this.updatePeerNameAndColor(this.getUserFromId(userId));
     }
-    if (stream) {
-      // Avoid flicker by checking if .srcObject already equals stream.
-      if (video.srcObject !== stream) video.srcObject = stream;
-    } else if (video) {
-      $(video).parent().remove();
-    }
+    // Avoid flicker by checking if .srcObject already equals stream.
+    if ($video[0].srcObject !== stream) $video[0].srcObject = stream;
   }
 
   addInterface(userId, stream) {

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -542,6 +542,7 @@ exports.rtc = new class {
         this.deactivate();
       }
     });
+    $(window).on('beforeunload', () => { this.hangupAll(); });
     $(window).on('unload', () => { this.hangupAll(); });
     if (rtcEnabled) {
       await this.activate();

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -498,7 +498,9 @@ exports.rtc = new class {
     });
   }
 
-  setupCheckboxes() {
+  async init(pad) {
+    this._pad = pad;
+
     // The checkbox shouldn't even exist if audio is not allowed
     if (this._settings.audio.disabled !== 'hard') {
       this.settingToCheckbox({
@@ -518,14 +520,7 @@ exports.rtc = new class {
         checkboxId: '#options-videoenabledonstart',
       });
     }
-  }
 
-  async init(pad) {
-    this._pad = pad;
-
-    this.setupCheckboxes();
-
-    // TODO - add this to setupCheckboxes. it's a bit involved.
     let rtcEnabled = padcookie.getPref('rtcEnabled');
     if (typeof rtcEnabled === 'undefined') rtcEnabled = $('#options-enablertc').prop('checked');
     if (this.avInURL()) rtcEnabled = true;

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -257,17 +257,14 @@ exports.rtc = new class {
     // Mute button
     // /////
 
-    const audioTrack = stream.getAudioTracks()[0];
     const audioHardDisabled = this._settings.audio.disabled === 'hard';
-    let initiallyMuted = true; // if there's no audio track, it's muted
-    if (audioTrack) initiallyMuted = !audioTrack.enabled;
-
+    const hasAudio = stream.getAudioTracks().some((t) => t.enabled);
     const $mute = $("<span class='interface-btn audio-btn buttonicon'>")
         .attr('title',
             audioHardDisabled ? 'Audio disallowed by admin'
-            : initiallyMuted ? 'Unmute'
-            : 'Mute')
-        .toggleClass('muted', initiallyMuted || audioHardDisabled)
+            : hasAudio ? 'Mute'
+            : 'Unmute')
+        .toggleClass('muted', !hasAudio || audioHardDisabled)
         .toggleClass('disallowed', audioHardDisabled);
 
     if (!audioHardDisabled) {
@@ -293,18 +290,14 @@ exports.rtc = new class {
 
     let $disableVideo = null;
     if (isLocal) {
-      const videoTrack = stream.getVideoTracks()[0];
       const videoHardDisabled = this._settings.video.disabled === 'hard';
-      let initiallyVideoEnabled = false; // if there's no video track, it's disabled
-      if (videoTrack) {
-        initiallyVideoEnabled = videoTrack.enabled;
-      }
+      const hasVideo = stream.getVideoTracks().some((t) => t.enabled);
       $disableVideo = $("<span class='interface-btn video-btn buttonicon'>")
           .attr('title',
               videoHardDisabled ? 'Video disallowed by admin'
-              : initiallyVideoEnabled ? 'Disable video'
+              : hasVideo ? 'Disable video'
               : 'Enable video')
-          .toggleClass('off', !initiallyVideoEnabled || videoHardDisabled)
+          .toggleClass('off', !hasVideo || videoHardDisabled)
           .toggleClass('disallowed', videoHardDisabled);
       if (!videoHardDisabled) {
         $disableVideo.on({

--- a/static/tests/frontend/specs/enable_disable.js
+++ b/static/tests/frontend/specs/enable_disable.js
@@ -6,7 +6,7 @@ describe('enable/disable', function () {
     for (const r of remainder) for (const h of head) yield [h, ...r];
   };
 
-  const testCases = cartesian([null, false, true], [null, false, true, 'YES', 'ignored']);
+  const testCases = cartesian([null, false, true], [null, false, true, 'NO', 'YES', 'ignored']);
 
   for (const [cookieVal, queryVal] of testCases) {
     describe(`cookie=${cookieVal} query=${queryVal}`, function () {
@@ -26,6 +26,7 @@ describe('enable/disable', function () {
         // Normalize queryVal to null/false/true.
         const queryNorm =
             !!queryVal === queryVal ? queryVal // Already boolean.
+            : queryVal === 'NO' ? false
             : queryVal === 'YES' ? true
             : null;
         const defaultChecked = !!chrome$.window.clientVars.webrtc.enabled;

--- a/static/tests/frontend/specs/enable_disable.js
+++ b/static/tests/frontend/specs/enable_disable.js
@@ -6,7 +6,7 @@ describe('enable/disable', function () {
     for (const r of remainder) for (const h of head) yield [h, ...r];
   };
 
-  const testCases = cartesian([null, false, true], [null, 'YES', 'ignored']);
+  const testCases = cartesian([null, false, true], [null, false, true, 'YES', 'ignored']);
 
   for (const [cookieVal, queryVal] of testCases) {
     describe(`cookie=${cookieVal} query=${queryVal}`, function () {
@@ -24,7 +24,10 @@ describe('enable/disable', function () {
         });
         chrome$ = helper.padChrome$;
         // Normalize queryVal to null/false/true.
-        const queryNorm = queryVal === 'YES' ? true : null;
+        const queryNorm =
+            !!queryVal === queryVal ? queryVal // Already boolean.
+            : queryVal === 'YES' ? true
+            : null;
         const defaultChecked = !!chrome$.window.clientVars.webrtc.enabled;
         wantChecked = (queryNorm || (queryNorm == null && cookieVal) ||
                        (queryNorm == null && cookieVal == null && defaultChecked));

--- a/static/tests/frontend/specs/errors.js
+++ b/static/tests/frontend/specs/errors.js
@@ -17,7 +17,8 @@ describe('error handling', function () {
   before(async function () {
     this.timeout(60000);
     await helper.aNewPad({
-      padPrefs: {fakeWebrtcFirefox: true, rtcEnabled: false},
+      padPrefs: {fakeWebrtcFirefox: true},
+      params: {av: false},
     });
     chrome$ = helper.padChrome$;
     await helper.waitForPromise(() => chrome$('#rtcbox').data('initialized'));

--- a/static/tests/frontend/specs/interface_buttons.js
+++ b/static/tests/frontend/specs/interface_buttons.js
@@ -211,10 +211,10 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
       // Make sure webrtc starts disabled so we have time to wrap getUserMedia
       await helper.aNewPad({
         padPrefs: {
-          // Disable WebRTC so we can change clientVars before activation.
-          rtcEnabled: true,
           fakeWebrtcFirefox: true,
         },
+        // Disable WebRTC so we can change clientVars before activation.
+        params: {av: false},
       });
       const chrome$ = helper.padChrome$;
       chrome$.window.clientVars.webrtc.audio.disabled = 'hard';

--- a/static/tests/frontend/specs/setStream.js
+++ b/static/tests/frontend/specs/setStream.js
@@ -51,8 +51,7 @@ describe('setStream()', function () {
           this.timeout(60000);
           await helper.aNewPad({
             // Disable WebRTC so we can install a mock getUserMedia() before it is called.
-            padPrefs: {rtcEnabled: false},
-            params: tc.params,
+            params: Object.assign({av: false}, tc.params),
           });
           chrome$ = helper.padChrome$;
           chrome$.window.navigator.mediaDevices.getUserMedia =

--- a/templates/settings.ejs
+++ b/templates/settings.ejs
@@ -1,5 +1,5 @@
 <p>
-  <input type="checkbox" id="options-enablertc" <%= enabled %>></input>
+  <input type="checkbox" id="options-enablertc" <%= enabled ? 'checked' : '' %>></input>
   <label for="options-enablertc" data-l10n-id="pad.settings.enablertc">Enable Audio/Video Chat</label>
 </p>
 <% if (!audio_hard_disabled) { %>

--- a/templates/settings.ejs
+++ b/templates/settings.ejs
@@ -1,5 +1,5 @@
 <p>
-  <input type="checkbox" id="options-enablertc" <%= enabled ? 'checked' : '' %>></input>
+  <input type="checkbox" id="options-enablertc"></input>
   <label for="options-enablertc" data-l10n-id="pad.settings.enablertc">Enable Audio/Video Chat</label>
 </p>
 <% if (!audio_hard_disabled) { %>


### PR DESCRIPTION
Multiple commits:
* Improve readability of settings processing
* Use empty string instead of `unchecked` for checkbox
* Always register `unload` handler
* Also call `hangupAll()` during `beforeunload` event
* Merge `setupCheckboxes()` into `init()`
* Use `URLSearchParams` to parse the query string
* Use `settingToCheckbox()` for `av` query parameter
* Add support for `av=NO`
* Coerce to boolean rather than compare with `true`
* Mute/unmute all tracks
* Improve readability of `<video>` element creation
* Check all tracks when checking audio/video enabled state
* Improve readability of `addInterface()`
* Move `<video>` element creation to `addInterface()`
* Use `hangupAll()` to clean up old connections when activating

cc @packardone 