### PR TITLE
Numerous fixes and improvements

### DIFF
--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -183,7 +183,9 @@ exports.rtc = new class {
     this.hangupAll();
     await Promise.all(this._pad.collabClient.getConnectedUsers().map(async ({userId}) => {
       if (userId === this.getUserId()) return;
-      await this.call(userId);
+      this.createPeerConnection(userId);
+      await this._pc[userId].setLocalDescription();
+      this.sendMessage(userId, {offer: this._pc[userId].localDescription});
     }));
   }
 
@@ -394,13 +396,6 @@ exports.rtc = new class {
     this._pc[userId].close();
     delete this._pc[userId];
     if (notify) this.sendMessage(userId, {hangup: 'hangup'});
-  }
-
-  async call(userId) {
-    if (!this._localStream) return;
-    if (!this._pc[userId]) this.createPeerConnection(userId);
-    await this._pc[userId].setLocalDescription();
-    this.sendMessage(userId, {offer: this._pc[userId].localDescription});
   }
 
   createPeerConnection(userId) {

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -265,14 +265,15 @@ exports.rtc = new class {
     const $interface = $('<div>')
         .addClass('interface-container')
         .attr('id', `interface_${videoId}`);
-    $('#rtcbox').append(
-        $('<div>')
-            .addClass('video-container')
-            .toggleClass('local-user', isLocal)
-            .css({'width': size, 'max-height': size})
-            .append($('<div>').addClass('user-name'))
-            .append($video)
-            .append($interface));
+    const $videoContainer = $('<div>')
+        .addClass('video-container')
+        .toggleClass('local-user', isLocal)
+        .css({'width': size, 'max-height': size})
+        .append($('<div>').addClass('user-name'))
+        .append($video)
+        .append($interface);
+    if (isLocal) $('#rtcbox').prepend($videoContainer);
+    else $('#rtcbox').append($videoContainer);
     this.updatePeerNameAndColor(this.getUserFromId(userId));
 
     // /////

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -599,6 +599,14 @@ exports.rtc = new class {
       // is starting. The video element will be deleted shortly (if it hasn't already been deleted)
       // so it's OK to ignore the error.
       if (err.name === 'AbortError') return;
+      // Browsers won't allow autoplayed video with sound until the user has interacted with the
+      // page or the page is already capturing audio or video. If playback is not permitted, mute
+      // the video and try again.
+      if (err.name === 'NotAllowedError' && !$video[0].muted) {
+        // The self view is always muted, so this click() only applies to videos of remote peers.
+        $(`#interface_${$video.attr('id')} .audio-btn`).click();
+        return await this.playVideo($video);
+      }
       throw err;
     }
   }

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -437,8 +437,8 @@ exports.rtc = new class {
   }
 
   hangup(userId) {
-    if (!this._pc[userId]) return;
     this.setStream(userId, null);
+    if (!this._pc[userId]) return;
     this._pc[userId].close();
     delete this._pc[userId];
     this.sendMessage(userId, {hangup: 'hangup'});

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -193,8 +193,8 @@ exports.rtc = new class {
     $('#rtcbox').hide();
     padcookie.setPref('rtcEnabled', false);
     this.hangupAll();
+    this.setStream(this._pad.getUserId(), null);
     if (this._localStream) {
-      this.setStream(this._pad.getUserId(), null);
       for (const track of this._localStream.getTracks()) track.stop();
       this._localStream = null;
     }

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -116,7 +116,7 @@ exports.rtc = new class {
   }
 
   userLeave(hookName, {userInfo: {userId}}) {
-    this.hangup(userId, false);
+    this.hangup(userId);
   }
 
   handleClientMessage_RTC_MESSAGE(hookName, {payload: {from, data}}) {
@@ -405,7 +405,7 @@ exports.rtc = new class {
   async receiveMessage(peer, {description, candidate, hangup}) {
     if (peer === this.getUserId()) return;
     if (hangup != null) {
-      this.hangup(peer, false);
+      this.hangup(peer);
       return;
     }
     if (this._pc[peer] == null) this.createPeerConnection(peer);
@@ -436,12 +436,12 @@ exports.rtc = new class {
     return this._pad.getUserId();
   }
 
-  hangup(userId, notify = true) {
+  hangup(userId) {
     if (!this._pc[userId]) return;
     this.setStream(userId, null);
     this._pc[userId].close();
     delete this._pc[userId];
-    if (notify) this.sendMessage(userId, {hangup: 'hangup'});
+    this.sendMessage(userId, {hangup: 'hangup'});
   }
 
   // See if the peer is interested in establishing a WebRTC connection. If the peer isn't interested

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -27,6 +27,9 @@ const toggleTracks = (tracks) => {
   return !enabledAfter; // Return true iff disabled (muted).
 };
 
+// Periods in element IDs make it hard to build a selector string because period is for class match.
+const getVideoId = (userId) => `video_${userId.replace(/\./g, '_')}`;
+
 exports.rtc = new class {
   constructor() {
     this._settings = null;
@@ -79,7 +82,7 @@ exports.rtc = new class {
     if (!userInfo) return;
     const {userId, name = html10n.get('pad.userlist.unnamed'), colorId = 0} = userInfo;
     const color = typeof colorId === 'number' ? clientVars.colorPalette[colorId] : colorId;
-    $(`#video_${userId.replace(/\./g, '_')}`)
+    $(`#${getVideoId(userId)}`)
         .css({'border-color': color})
         .siblings('.user-name').text(name);
   }
@@ -216,8 +219,7 @@ exports.rtc = new class {
   }
 
   setStream(userId, stream) {
-    const videoId = `video_${userId.replace(/\./g, '_')}`;
-    let $video = $(`#${videoId}`);
+    let $video = $(`#${getVideoId(userId)}`);
     if (!stream) {
       $video.parent().remove();
       return;
@@ -249,7 +251,7 @@ exports.rtc = new class {
   }
 
   addInterface(userId, isLocal) {
-    const videoId = `video_${userId.replace(/\./g, '_')}`;
+    const videoId = getVideoId(userId);
     const size = `${this._settings.video.sizes.small}px`;
     const $video = $('<video>')
         .attr({

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -366,11 +366,6 @@ exports.rtc = new class {
     if (offer != null) {
       if (this._pc[peer]) this.hangup(peer, false);
       this.createPeerConnection(peer);
-      if (this._localStream && !this._pc[peer].getSenders().length) {
-        for (const track of this._localStream.getTracks()) {
-          this._pc[peer].addTrack(track, this._localStream);
-        }
-      }
       await this._pc[peer].setRemoteDescription(offer);
       await this._pc[peer].setLocalDescription();
       this.sendMessage(peer, {answer: this._pc[peer].localDescription});
@@ -404,9 +399,6 @@ exports.rtc = new class {
   async call(userId) {
     if (!this._localStream) return;
     if (!this._pc[userId]) this.createPeerConnection(userId);
-    for (const track of this._localStream.getTracks()) {
-      this._pc[userId].addTrack(track, this._localStream);
-    }
     await this._pc[userId].setLocalDescription();
     this.sendMessage(userId, {offer: this._pc[userId].localDescription});
   }
@@ -437,6 +429,11 @@ exports.rtc = new class {
         throw new Error('New track associated with unexpected stream');
       }
     });
+    if (this._localStream != null) {
+      for (const track of this._localStream.getTracks()) {
+        this._pc[userId].addTrack(track, this._localStream);
+      }
+    }
   }
 
   // Connect a setting to a checkbox. To be called on initialization.

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -407,18 +407,18 @@ exports.rtc = new class {
       this.hangup(peer, false);
       return;
     }
+    if (this._pc[peer] == null) this.createPeerConnection(peer);
+    const pc = this._pc[peer];
     if (offer != null) {
-      if (this._pc[peer]) this.hangup(peer, false);
-      this.createPeerConnection(peer);
-      await this._pc[peer].setRemoteDescription(offer);
-      await this._pc[peer].setLocalDescription();
-      this.sendMessage(peer, {answer: this._pc[peer].localDescription});
+      await pc.setRemoteDescription(offer);
+      await pc.setLocalDescription();
+      this.sendMessage(peer, {answer: pc.localDescription});
     }
     if (answer != null) {
-      if (this._pc[peer]) await this._pc[peer].setRemoteDescription(answer);
+      await pc.setRemoteDescription(answer);
     }
     if (candidate != null) {
-      if (this._pc[peer]) await this._pc[peer].addIceCandidate(candidate);
+      await pc.addIceCandidate(candidate);
     }
   }
 

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -128,6 +128,21 @@ class PeerState extends EventTarget {
       await pc.setLocalDescription();
       this._sendMessage({description: pc.localDescription});
     });
+    pc.addEventListener('connectionstatechange', () => {
+      switch (pc.connectionState) {
+        case 'closed': this.close(true); break;
+        // From reading the spec it is not clear what the possible state transitions are, but it
+        // seems that on at least Chrome 90 the 'failed' state is terminal (it can never go back to
+        // working).
+        case 'failed': this.close(true); break;
+      }
+    });
+    pc.addEventListener('iceconnectionstatechange', () => {
+      switch (pc.iceConnectionState) {
+        case 'closed': this.close(true); break;
+        case 'failed': pc.restartIce(); break;
+      }
+    });
 
     if (this._pc != null) this._pc.close();
     this._pc = pc;

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -259,8 +259,8 @@ exports.rtc = new class {
     // Mute button
     // /////
 
-    const audioHardDisabled = this._settings.audio.disabled === 'hard';
-    const hasAudio = stream.getAudioTracks().some((t) => t.enabled);
+    const audioHardDisabled = isLocal && this._settings.audio.disabled === 'hard';
+    const hasAudio = !isLocal || stream.getAudioTracks().some((t) => t.enabled);
     $interface.append($('<span>')
         .addClass('interface-btn audio-btn buttonicon')
         .attr('title',

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -523,10 +523,12 @@ exports.rtc = new class {
     debug('deactivating');
     $checkbox.prop('disabled', true);
     try {
-      $('#rtcbox').hide();
       padcookie.setPref('rtcEnabled', false);
       this.hangupAll();
       this.setStream(this.getUserId(), null);
+      const $rtcbox = $('#rtcbox');
+      $rtcbox.empty(); // In case any peer videos didn't get cleaned up for some reason.
+      $rtcbox.hide();
       for (const track of this._localTracks.stream.getTracks()) {
         this._localTracks.setTrack(track.kind, null);
       }

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -109,6 +109,9 @@ exports.rtc = new class {
   }
 
   userJoinOrUpdate(hookName, {userInfo}) {
+    const {userId} = userInfo;
+    if (!this._isActive || !userId) return;
+    if (userId !== this.getUserId()) this.invitePeer(userId);
     this.updatePeerNameAndColor(userInfo);
   }
 

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -563,7 +563,7 @@ exports.rtc = new class {
     if ($video.length === 0) $video = this.addInterface(userId, isLocal);
     if (isLocal) {
       // Sync the interface for the self view with the state of the outgoing stream.
-      const $interface = $video.siblings('.interface-container');
+      const $interface = $(`#interface_${getVideoId(userId)}`);
       const hasAudio = stream.getAudioTracks().some((t) => t.enabled);
       if (this._settings.audio.disabled !== 'hard') {
         $interface.children('.audio-btn')

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -406,6 +406,7 @@ exports.rtc = new class {
   createPeerConnection(userId) {
     if (this._pc[userId]) {
       console.log('WARNING creating PC connection even though one exists', userId);
+      this._pc[userId].close();
     }
     this._pc[userId] = new RTCPeerConnection({iceServers: this._settings.iceServers});
     this._pc[userId].onicecandidate = (event) => {

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -224,7 +224,7 @@ exports.rtc = new class {
     }
 
     this._localStream = stream;
-    this.setStream(this._pad.getUserId(), stream);
+    this.setStream(this.getUserId(), stream);
     this.hangupAll();
     await Promise.all(this._pad.collabClient.getConnectedUsers().map(async ({userId}) => {
       if (userId === this.getUserId()) return;
@@ -240,7 +240,7 @@ exports.rtc = new class {
     $('#rtcbox').hide();
     padcookie.setPref('rtcEnabled', false);
     this.hangupAll();
-    this.setStream(this._pad.getUserId(), null);
+    this.setStream(this.getUserId(), null);
     if (this._localStream) {
       for (const track of this._localStream.getTracks()) track.stop();
       this._localStream = null;

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -181,9 +181,9 @@ exports.rtc = new class {
     this._localStream = stream;
     this.setStream(this._pad.getUserId(), stream);
     this.hangupAll();
-    await Promise.all(this._pad.collabClient.getConnectedUsers().map(async (user) => {
-      if (user.userId === this.getUserId()) return;
-      await this.call(user.userId);
+    await Promise.all(this._pad.collabClient.getConnectedUsers().map(async ({userId}) => {
+      if (userId === this.getUserId()) return;
+      await this.call(userId);
     }));
   }
 

--- a/static/tests/frontend/specs/setStream.js
+++ b/static/tests/frontend/specs/setStream.js
@@ -61,7 +61,7 @@ describe('setStream()', function () {
           ownUserId = chrome$.window.ep_webrtc.getUserId();
           ownVideoId = `video_${ownUserId.replace(/\./g, '_')}`;
           ownInterfaceId = `interface_${ownVideoId}`;
-          chrome$.window.ep_webrtc.setStream(
+          await chrome$.window.ep_webrtc.setStream(
               otherUserId, fakeStream(chrome$.window.document, tc.peer));
         });
 
@@ -122,7 +122,7 @@ describe('setStream()', function () {
       ownUserId = chrome$.window.ep_webrtc.getUserId();
       ownVideoId = `video_${ownUserId.replace(/\./g, '_')}`;
       ownInterfaceId = `interface_${ownVideoId}`;
-      chrome$.window.ep_webrtc.setStream(
+      await chrome$.window.ep_webrtc.setStream(
           otherUserId, fakeStream(chrome$.window.document, {audio: false, video: false}));
     });
 

--- a/static/tests/frontend/specs/setStream.js
+++ b/static/tests/frontend/specs/setStream.js
@@ -89,7 +89,10 @@ describe('setStream()', function () {
         it('peer interface', async function () {
           const $audioBtn = chrome$(`#${otherInterfaceId} .audio-btn`);
           expect($audioBtn.length).to.equal(1);
-          expect($audioBtn.hasClass('muted')).to.equal(!tc.peer.audio);
+          // Only initially muted if the browser doesn't give permission to autoplay unless muted.
+          // (A peer without an audio track might later add an audio track; if so, the audio should
+          // start playing locally without the local user clicking anything.)
+          expect($audioBtn.hasClass('muted')).to.equal(chrome$(`#${otherVideoId}`).prop('muted'));
           const $videoBtn = chrome$(`#${otherInterfaceId} .video-btn`);
           expect($videoBtn.length).to.equal(0);
           const $enlargeBtn = chrome$(`#${otherInterfaceId} .enlarge-btn`);
@@ -148,7 +151,11 @@ describe('setStream()', function () {
     it('peer interface', async function () {
       const $audioBtn = chrome$(`#${otherInterfaceId} .audio-btn`);
       expect($audioBtn.length).to.equal(1);
-      expect($audioBtn.hasClass('muted')).to.equal(true);
+      // Mute state only depends on whether the browser gives permission to autoplay when unmuted.
+      // Hard disabling only affects what the local client sends; it doesn't affect what the remote
+      // peer sends. (Both the local client and the remote peer should see the same settings,
+      // however.)
+      expect($audioBtn.hasClass('muted')).to.equal(chrome$(`#${otherVideoId}`).prop('muted'));
       const $videoBtn = chrome$(`#${otherInterfaceId} .video-btn`);
       expect($videoBtn.length).to.equal(0);
       const $enlargeBtn = chrome$(`#${otherInterfaceId} .enlarge-btn`);


### PR DESCRIPTION
Multiple commits:
* Always assume remote streams could have audio
* Sync interface buttons for self view with stream state
* Factor out duplicate video element ID code
* Always put the self view first
* Unconditionally clear the self view
* Add support for message broadcasts
* Simplify RTC_MESSAGE format a bit
* Factor out duplicate `addTrack()` calls
* Close RTCPeerConnection before overwriting it
* Use destructuring to improve readability
* Inline `call()`
* Inline `init()` into `postAceInit()`
* Consistently use `this.getUserId()`
* Use `negotiationneeded` to trigger offer
* Always create peer connection when receiving a message
* Combine offer/answer into a single description handler
* Send an invite to connect rather than directly connect
* Invite newly discovered peers
* Always notify peers when hanging up
* Always clear out the video element
* Use a Map to hold peer state
* Use a permanent MediaStream for local tracks
* Move peer negotiation logic to a new PeerState class
* Support dynamic local track addition/removal
* Handle RTC connection closes
* Reset the RTC connection on error
* Move message handling to closures
* Redo connection negotiation to avoid race conditions
* Disable checkbox while changing state
* Add client-side debug logging
* Use element ID to find interface element
* Defensively clean out `#rtcbox` when deactivating
* Explicitly call `.play()` rather than rely on autoplay
* Try muting if the browser blocks autoplay
* Automatically unmute auto-muted videos
* Move media acquisition logic to a separate function

cc @packardone 