### PR TITLE
tests: Fake webcam improvements

### DIFF
--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -475,16 +475,10 @@ exports.rtc = new class {
         addAudioTrack && addVideoTrack ? 'camera and microphone'
         : addAudioTrack ? 'microphone'
         : 'camera'}`);
-      const constraints = {
+      const stream = await window.navigator.mediaDevices.getUserMedia({
         audio: addAudioTrack,
         video: addVideoTrack && {width: {max: 320}, height: {max: 240}},
-      };
-      if (padcookie.getPref('fakeWebrtcFirefox')) {
-        // The equivalent is done for chromium with cli option:
-        // --use-fake-device-for-media-stream
-        constraints.fake = true;
-      }
-      const stream = await window.navigator.mediaDevices.getUserMedia(constraints);
+      });
       debug('successfully accessed device(s)');
       for (const track of stream.getTracks()) this._localTracks.setTrack(track.kind, track);
     }

--- a/static/tests/frontend/specs/audio_video_on_start.js
+++ b/static/tests/frontend/specs/audio_video_on_start.js
@@ -15,7 +15,7 @@ describe('audio/video on/off according to query parameters/cookies', function ()
         params: queryVal == null ? {} : {[`webrtc${avType}enabled`]: queryVal},
       });
       const chrome$ = helper.padChrome$;
-      await helper.waitForPromise(() => chrome$('#rtcbox').data('initialized'));
+      await helper.waitForPromise(() => chrome$('#rtcbox').data('initialized'), 5000);
       const {disabled} = chrome$.window.clientVars.webrtc[avType];
       const checkbox = chrome$(`#options-${avType}enabledonstart`);
       if (disabled === 'hard') {

--- a/static/tests/frontend/specs/audio_video_on_start.js
+++ b/static/tests/frontend/specs/audio_video_on_start.js
@@ -14,7 +14,6 @@ describe('audio/video on/off according to query parameters/cookies', function ()
       await helper.aNewPad({
         padPrefs: Object.assign({
           rtcEnabled: true,
-          fakeWebrtcFirefox: true,
         }, cookieVal == null ? {} : {[`${avType}EnabledOnStart`]: cookieVal}),
         params: queryVal == null ? {} : {[`webrtc${avType}enabled`]: queryVal},
       });

--- a/static/tests/frontend/specs/audio_video_on_start.js
+++ b/static/tests/frontend/specs/audio_video_on_start.js
@@ -1,11 +1,8 @@
 'use strict';
 
-describe('audio/video on/off according to query parameters/cookies', function () {
-  const cartesian = function* (head, ...tail) {
-    const remainder = tail.length > 0 ? cartesian(...tail) : [[]];
-    for (const r of remainder) for (const h of head) yield [h, ...r];
-  };
+const {cartesian} = require('ep_webrtc/static/tests/frontend/utils');
 
+describe('audio/video on/off according to query parameters/cookies', function () {
   const testCases = cartesian(['audio', 'video'], [null, false, true], [null, false, true]);
 
   for (const [avType, cookieVal, queryVal] of testCases) {

--- a/static/tests/frontend/specs/checkbox.js
+++ b/static/tests/frontend/specs/checkbox.js
@@ -1,11 +1,8 @@
 'use strict';
 
-describe('settingToCheckbox', function () {
-  const cartesian = function* (head, ...tail) {
-    const remainder = tail.length > 0 ? cartesian(...tail) : [[]];
-    for (const r of remainder) for (const h of head) yield [h, ...r];
-  };
+const {cartesian} = require('ep_webrtc/static/tests/frontend/utils');
 
+describe('settingToCheckbox', function () {
   const testCases = [
     ...cartesian([false, true], [null, false, true], [null, false, true]),
   ].map(([defaultVal, cookieVal, queryVal], i) => ({

--- a/static/tests/frontend/specs/checkbox.js
+++ b/static/tests/frontend/specs/checkbox.js
@@ -25,10 +25,7 @@ describe('settingToCheckbox', function () {
   before(async function () {
     this.timeout(60000);
     await helper.aNewPad({
-      padPrefs: Object.assign({
-        rtcEnabled: true,
-        fakeWebrtcFirefox: true,
-      }, ...testCases
+      padPrefs: Object.assign({rtcEnabled: true}, ...testCases
           .filter(({cookieVal}) => cookieVal != null)
           .map(({cookieVal, i}) => ({[`cookie${i}`]: cookieVal}))),
       params: Object.assign({}, ...testCases

--- a/static/tests/frontend/specs/checkbox.js
+++ b/static/tests/frontend/specs/checkbox.js
@@ -22,10 +22,10 @@ describe('settingToCheckbox', function () {
   before(async function () {
     this.timeout(60000);
     await helper.aNewPad({
-      padPrefs: Object.assign({rtcEnabled: true}, ...testCases
+      padPrefs: Object.assign({}, ...testCases
           .filter(({cookieVal}) => cookieVal != null)
           .map(({cookieVal, i}) => ({[`cookie${i}`]: cookieVal}))),
-      params: Object.assign({}, ...testCases
+      params: Object.assign({av: false}, ...testCases
           .filter(({queryVal}) => queryVal != null)
           .map(({queryVal, i}) => ({[`urlVar${i}`]: queryVal}))),
     });

--- a/static/tests/frontend/specs/enable_disable.js
+++ b/static/tests/frontend/specs/enable_disable.js
@@ -17,9 +17,7 @@ describe('enable/disable', function () {
       before(async function () {
         this.timeout(60000);
         await helper.aNewPad({
-          padPrefs: Object.assign({
-            fakeWebrtcFirefox: true,
-          }, cookieVal == null ? {} : {rtcEnabled: cookieVal}),
+          padPrefs: cookieVal == null ? {} : {rtcEnabled: cookieVal},
           params: queryVal == null ? {} : {av: queryVal},
         });
         chrome$ = helper.padChrome$;

--- a/static/tests/frontend/specs/enable_disable.js
+++ b/static/tests/frontend/specs/enable_disable.js
@@ -1,11 +1,8 @@
 'use strict';
 
-describe('enable/disable', function () {
-  const cartesian = function* (head, ...tail) {
-    const remainder = tail.length > 0 ? cartesian(...tail) : [[]];
-    for (const r of remainder) for (const h of head) yield [h, ...r];
-  };
+const {cartesian} = require('ep_webrtc/static/tests/frontend/utils');
 
+describe('enable/disable', function () {
   const testCases = cartesian([null, false, true], [null, false, true, 'NO', 'YES', 'ignored']);
 
   for (const [cookieVal, queryVal] of testCases) {

--- a/static/tests/frontend/specs/enable_disable.js
+++ b/static/tests/frontend/specs/enable_disable.js
@@ -28,7 +28,7 @@ describe('enable/disable', function () {
         wantChecked = (queryNorm || (queryNorm == null && cookieVal) ||
                        (queryNorm == null && cookieVal == null && defaultChecked));
         checkbox = chrome$('#options-enablertc');
-        await helper.waitForPromise(() => chrome$('#rtcbox').data('initialized'));
+        await helper.waitForPromise(() => chrome$('#rtcbox').data('initialized'), 5000);
       });
 
       it('checkbox is checked/unchecked', async function () {

--- a/static/tests/frontend/specs/errors.js
+++ b/static/tests/frontend/specs/errors.js
@@ -16,10 +16,7 @@ describe('error handling', function () {
 
   before(async function () {
     this.timeout(60000);
-    await helper.aNewPad({
-      padPrefs: {fakeWebrtcFirefox: true},
-      params: {av: false},
-    });
+    await helper.aNewPad({params: {av: false}});
     chrome$ = helper.padChrome$;
     await helper.waitForPromise(() => chrome$('#rtcbox').data('initialized'));
     enable = chrome$('#options-enablertc');

--- a/static/tests/frontend/specs/interface_buttons.js
+++ b/static/tests/frontend/specs/interface_buttons.js
@@ -30,22 +30,10 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
         },
       });
       const chrome$ = helper.padChrome$;
-
-      await helper.waitForPromise(
-          () => chrome$ && chrome$('#options-enablertc').length === 1, 2000);
       wrapGetUserMedia();
-
-      const $enableRtc = chrome$('#options-enablertc');
-      $enableRtc.click(); // Turn it on late so that wrapGetUserMedia works
-
-      await helper.waitForPromise(
-          () => (chrome$('.audio-btn').length === 1 && chrome$('.video-btn').length === 1 &&
-                 audioTrack != null && videoTrack != null),
-          1000);
-      // Video interface buttons are added twice, and there's no good way besides a timeout to tell
-      // when it's done being called the second time. We want it to be finished so our test is
-      // stable.
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      // Clicking $('#options-enablertc') also activates, but calling activate() directly blocks
+      // until activation is complete.
+      await chrome$.window.ep_webrtc.activate();
     });
 
     it('enlarges then shrinks', async function () {
@@ -139,21 +127,10 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
         },
       });
       const chrome$ = helper.padChrome$;
-
-      await helper.waitForPromise(
-          () => chrome$ && chrome$('#options-enablertc').length === 1, 2000);
       wrapGetUserMedia();
-      const $enableRtc = chrome$('#options-enablertc');
-      $enableRtc.click(); // Turn it on late so that wrapGetUserMedia works
-
-      await helper.waitForPromise(
-          () => (chrome$('.audio-btn').length === 1 && chrome$('.video-btn').length === 1 &&
-                 audioTrack != null && videoTrack != null),
-          1000);
-      // Video interface buttons are added twice, and there's no good way besides a timeout to tell
-      // when it's done being called the second time. We want it to be finished so our test is
-      // stable.
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      // Clicking $('#options-enablertc') also activates, but calling activate() directly blocks
+      // until activation is complete.
+      await chrome$.window.ep_webrtc.activate();
     });
 
     it('unmutes then mutes', async function () {
@@ -212,14 +189,10 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
       const chrome$ = helper.padChrome$;
       chrome$.window.clientVars.webrtc.audio.disabled = 'hard';
       chrome$.window.clientVars.webrtc.video.disabled = 'hard';
-      chrome$('#options-enablertc').click();
-      await helper.waitForPromise(
-          () => (chrome$('.audio-btn').length === 1 && chrome$('.video-btn').length === 1), 1000);
       wrapGetUserMedia();
-      // Video interface buttons are added twice, and there's no good way besides a timeout to tell
-      // when it's done being called the second time. We want it to be finished so our test is
-      // stable.
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      // Clicking $(#options-enablertc) also activates, but calling activate() directly blocks until
+      // activation is complete.
+      await chrome$.window.ep_webrtc.activate();
     });
 
     it('cannot mute or unmute', async function () {

--- a/static/tests/frontend/specs/interface_buttons.js
+++ b/static/tests/frontend/specs/interface_buttons.js
@@ -1,14 +1,15 @@
 'use strict';
 
+const {fakeGetUserMedia} = require('ep_webrtc/static/tests/frontend/utils');
+
 describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlarge', function () {
   let audioTrack;
   let videoTrack;
 
-  const wrapGetUserMedia = () => {
+  const installFakeGetUserMedia = () => {
     const chrome$ = helper.padChrome$;
-    const oldGetUserMedia = chrome$.window.navigator.mediaDevices.getUserMedia;
     chrome$.window.navigator.mediaDevices.getUserMedia = async (constraints) => {
-      const stream = await oldGetUserMedia.call(chrome$.window.navigator.mediaDevices, constraints);
+      const stream = await fakeGetUserMedia(constraints);
       audioTrack = stream.getAudioTracks()[0];
       videoTrack = stream.getVideoTracks()[0];
       return stream;
@@ -30,7 +31,7 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
         },
       });
       const chrome$ = helper.padChrome$;
-      wrapGetUserMedia();
+      installFakeGetUserMedia();
       // Clicking $('#options-enablertc') also activates, but calling activate() directly blocks
       // until activation is complete.
       await chrome$.window.ep_webrtc.activate();
@@ -127,7 +128,7 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
         },
       });
       const chrome$ = helper.padChrome$;
-      wrapGetUserMedia();
+      installFakeGetUserMedia();
       // Clicking $('#options-enablertc') also activates, but calling activate() directly blocks
       // until activation is complete.
       await chrome$.window.ep_webrtc.activate();
@@ -189,7 +190,7 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
       const chrome$ = helper.padChrome$;
       chrome$.window.clientVars.webrtc.audio.disabled = 'hard';
       chrome$.window.clientVars.webrtc.video.disabled = 'hard';
-      wrapGetUserMedia();
+      installFakeGetUserMedia();
       // Clicking $(#options-enablertc) also activates, but calling activate() directly blocks until
       // activation is complete.
       await chrome$.window.ep_webrtc.activate();

--- a/static/tests/frontend/specs/interface_buttons.js
+++ b/static/tests/frontend/specs/interface_buttons.js
@@ -25,7 +25,6 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
       await helper.aNewPad({
         padPrefs: {
           rtcEnabled: false,
-          fakeWebrtcFirefox: true,
           audioEnabledOnStart: true,
           videoEnabledOnStart: true,
         },
@@ -135,7 +134,6 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
       await helper.aNewPad({
         padPrefs: {
           rtcEnabled: false,
-          fakeWebrtcFirefox: true,
           audioEnabledOnStart: false,
           videoEnabledOnStart: false,
         },
@@ -208,14 +206,9 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
       this.timeout(60000);
       audioTrack = null;
       videoTrack = null;
-      // Make sure webrtc starts disabled so we have time to wrap getUserMedia
-      await helper.aNewPad({
-        padPrefs: {
-          fakeWebrtcFirefox: true,
-        },
-        // Disable WebRTC so we can change clientVars before activation.
-        params: {av: false},
-      });
+      // Make sure webrtc starts disabled so we have time to wrap getUserMedia and change clientVars
+      // before activation.
+      await helper.aNewPad({params: {av: false}});
       const chrome$ = helper.padChrome$;
       chrome$.window.clientVars.webrtc.audio.disabled = 'hard';
       chrome$.window.clientVars.webrtc.video.disabled = 'hard';

--- a/static/tests/frontend/specs/race_conditions.js
+++ b/static/tests/frontend/specs/race_conditions.js
@@ -200,7 +200,6 @@ describe('Race conditions that leave audio/video track enabled', function () {
       await helper.aNewPad({
         padPrefs: {
           rtcEnabled: false,
-          fakeWebrtcFirefox: true,
           audioEnabledOnStart: true,
           videoEnabledOnStart: true,
         },
@@ -269,7 +268,6 @@ describe('Race conditions that leave audio/video track enabled', function () {
       await helper.aNewPad({
         padPrefs: {
           rtcEnabled: false,
-          fakeWebrtcFirefox: true,
           audioEnabledOnStart: false,
           videoEnabledOnStart: false,
         },

--- a/static/tests/frontend/specs/race_conditions.js
+++ b/static/tests/frontend/specs/race_conditions.js
@@ -212,35 +212,30 @@ describe('Race conditions that leave audio/video track enabled', function () {
     });
 
     it('click, deactivate, activate', async function () {
-      this.timeout(5000);
       expect(audioTrack.enabled).to.equal(true);
       expect(videoTrack.enabled).to.equal(true);
       await testClickDeactivateActivate();
     });
 
     it('deactivate, click, activate', async function () {
-      this.timeout(5000);
       expect(audioTrack.enabled).to.equal(true);
       expect(videoTrack.enabled).to.equal(true);
       await testDeactivateClickActivate();
     });
 
     it('deactivate, activate, click', async function () {
-      this.timeout(5000);
       expect(audioTrack.enabled).to.equal(true);
       expect(videoTrack.enabled).to.equal(true);
       await testDeactivateActivateClick();
     });
 
     it('click while reactivate', async function () {
-      this.timeout(5000);
       expect(audioTrack.enabled).to.equal(true);
       expect(videoTrack.enabled).to.equal(true);
       await testClickWhileReactivate();
     });
 
     it('many clicks', async function () {
-      this.timeout(5000);
       expect(audioTrack.enabled).to.equal(true);
       expect(videoTrack.enabled).to.equal(true);
       await testManyClicks();

--- a/static/tests/frontend/specs/race_conditions.js
+++ b/static/tests/frontend/specs/race_conditions.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {fakeGetUserMedia} = require('ep_webrtc/static/tests/frontend/utils');
+
 describe('Race conditions that leave audio/video track enabled', function () {
   // The idea here is to place high value on making sure that the "mute" and "video-off" buttons in
   // the video interfaces match with the audioTrack.enabled/videoTrack.enabled, so that users don't
@@ -15,11 +17,10 @@ describe('Race conditions that leave audio/video track enabled', function () {
 
   // wrap getUserMedia such that it grabs a copy of audio and video tracks for inspection after it's
   // done
-  const wrapGetUserMedia = () => {
+  const installFakeGetUserMedia = () => {
     const chrome$ = helper.padChrome$;
-    const oldGetUserMedia = chrome$.window.navigator.mediaDevices.getUserMedia;
     chrome$.window.navigator.mediaDevices.getUserMedia = async (constraints) => {
-      const stream = await oldGetUserMedia.call(chrome$.window.navigator.mediaDevices, constraints);
+      const stream = await fakeGetUserMedia(constraints);
       audioTrack = stream.getAudioTracks()[0];
       videoTrack = stream.getVideoTracks()[0];
       return stream;
@@ -205,7 +206,7 @@ describe('Race conditions that leave audio/video track enabled', function () {
         },
       });
       const chrome$ = helper.padChrome$;
-      wrapGetUserMedia();
+      installFakeGetUserMedia();
       // Clicking $('#options-enablertc') also activates, but calling activate() directly blocks
       // until activation is complete.
       await chrome$.window.ep_webrtc.activate();
@@ -256,7 +257,7 @@ describe('Race conditions that leave audio/video track enabled', function () {
         },
       });
       const chrome$ = helper.padChrome$;
-      wrapGetUserMedia();
+      installFakeGetUserMedia();
       // Clicking $('#options-enablertc') also activates, but calling activate() directly blocks
       // until activation is complete.
       await chrome$.window.ep_webrtc.activate();

--- a/static/tests/frontend/specs/race_conditions.js
+++ b/static/tests/frontend/specs/race_conditions.js
@@ -205,22 +205,10 @@ describe('Race conditions that leave audio/video track enabled', function () {
         },
       });
       const chrome$ = helper.padChrome$;
-
-      await helper.waitForPromise(
-          () => chrome$ && chrome$('#options-enablertc').length === 1, 2000);
       wrapGetUserMedia();
-
-      const $enableRtc = chrome$('#options-enablertc');
-      $enableRtc.click(); // Turn it on late so that wrapGetUserMedia works
-
-      await helper.waitForPromise(
-          () => (chrome$('.audio-btn').length === 1 && chrome$('.video-btn').length === 1 &&
-                 audioTrack != null && videoTrack != null),
-          1000);
-      // Video interface buttons are added twice, and there's no good way besides a timeout to tell
-      // when it's done being called the second time. We want it to be finished so our test is
-      // stable.
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      // Clicking $('#options-enablertc') also activates, but calling activate() directly blocks
+      // until activation is complete.
+      await chrome$.window.ep_webrtc.activate();
     });
 
     it('click, deactivate, activate', async function () {
@@ -273,22 +261,10 @@ describe('Race conditions that leave audio/video track enabled', function () {
         },
       });
       const chrome$ = helper.padChrome$;
-
-      await helper.waitForPromise(
-          () => chrome$ && chrome$('#options-enablertc').length === 1, 2000);
       wrapGetUserMedia();
-
-      const $enableRtc = chrome$('#options-enablertc');
-      $enableRtc.click(); // Turn it on late so that wrapGetUserMedia works
-
-      await helper.waitForPromise(
-          () => (chrome$('.audio-btn').length === 1 && chrome$('.video-btn').length === 1 &&
-                 audioTrack != null && videoTrack != null),
-          1000);
-      // Video interface buttons are added twice, and there's no good way besides a timeout to tell
-      // when it's done being called the second time. We want it to be finished so our test is
-      // stable.
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      // Clicking $('#options-enablertc') also activates, but calling activate() directly blocks
+      // until activation is complete.
+      await chrome$.window.ep_webrtc.activate();
     });
 
     it('click, deactivate, activate', async function () {

--- a/static/tests/frontend/specs/setStream.js
+++ b/static/tests/frontend/specs/setStream.js
@@ -56,8 +56,9 @@ describe('setStream()', function () {
           });
           chrome$ = helper.padChrome$;
           chrome$.window.navigator.mediaDevices.getUserMedia = fakeGetUserMedia;
-          chrome$('#options-enablertc').click();
-          await helper.waitForPromise(() => chrome$('#rtcbox').data('initialized'));
+          // Clicking $(#options-enablertc) also activates, but calling activate() directly blocks
+          // until activation is complete.
+          await chrome$.window.ep_webrtc.activate();
           ownUserId = chrome$.window.ep_webrtc.getUserId();
           ownVideoId = `video_${ownUserId.replace(/\./g, '_')}`;
           ownInterfaceId = `interface_${ownVideoId}`;
@@ -120,8 +121,9 @@ describe('setStream()', function () {
       chrome$.window.navigator.mediaDevices.getUserMedia = fakeGetUserMedia;
       chrome$.window.clientVars.webrtc.audio.disabled = 'hard';
       chrome$.window.clientVars.webrtc.video.disabled = 'hard';
-      chrome$('#options-enablertc').click();
-      await helper.waitForPromise(() => chrome$('#rtcbox').data('initialized'));
+      // Clicking $(#options-enablertc) also activates, but calling activate() directly blocks until
+      // activation is complete.
+      await chrome$.window.ep_webrtc.activate();
       ownUserId = chrome$.window.ep_webrtc.getUserId();
       ownVideoId = `video_${ownUserId.replace(/\./g, '_')}`;
       ownInterfaceId = `interface_${ownVideoId}`;

--- a/static/tests/frontend/specs/setStream.js
+++ b/static/tests/frontend/specs/setStream.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {cartesian} = require('ep_webrtc/static/tests/frontend/utils');
+const {cartesian, fakeGetUserMedia} = require('ep_webrtc/static/tests/frontend/utils');
 
 describe('setStream()', function () {
   let chrome$;
@@ -8,36 +8,6 @@ describe('setStream()', function () {
   const otherVideoId = `video_${otherUserId.replace(/\./g, '_')}`;
   const otherInterfaceId = `interface_${otherVideoId}`;
   let ownUserId, ownVideoId, ownInterfaceId;
-
-  const makeSilentAudioTrack = () => {
-    const ctx = new AudioContext();
-    const oscillator = ctx.createOscillator();
-    const dst = oscillator.connect(ctx.createMediaStreamDestination());
-    oscillator.start();
-    return dst.stream.getAudioTracks()[0];
-  };
-
-  const makeVideoTrack = () => {
-    const canvas = helper.padChrome$.window.document.createElement('canvas');
-    canvas.width = 160;
-    canvas.height = 120;
-    const ctx = canvas.getContext('2d');
-    ctx.fillStyle = `#${Math.floor(Math.random() * 2 ** 24).toString(16).padStart(6, '0')}`;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    return canvas.captureStream().getVideoTracks()[0];
-  };
-
-  // Creates dummy audio and/or video tracks. Limitations:
-  //   - `audio` and `video` are treated as Booleans (video size requirements are ignored).
-  //   - Most browsers prohibit audio until there has been some user interaction with the page or
-  //     the real getUserMedia() has been called.
-  const fakeGetUserMedia = async ({audio, video}) => {
-    if (!audio && !video) throw new DOMException('either audio or video is required', 'TypeError');
-    return new MediaStream([
-      ...(audio ? [makeSilentAudioTrack()] : []),
-      ...(video ? [makeVideoTrack()] : []),
-    ]);
-  };
 
   describe('Audio and video enabled', function () {
     const testCases = [...cartesian(...Array(4).fill([false, true]))].map(

--- a/static/tests/frontend/specs/setStream.js
+++ b/static/tests/frontend/specs/setStream.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {cartesian} = require('ep_webrtc/static/tests/frontend/utils');
+
 describe('setStream()', function () {
   let chrome$;
   const otherUserId = 'other_user_id';
@@ -32,11 +34,6 @@ describe('setStream()', function () {
     ...(audio ? [makeSilentAudioTrack()] : []),
     ...(video ? [makeVideoTrack(document)] : []),
   ]);
-
-  const cartesian = function* (head, ...tail) {
-    const remainder = tail.length > 0 ? cartesian(...tail) : [[]];
-    for (const r of remainder) for (const h of head) yield [h, ...r];
-  };
 
   describe('Audio and video enabled', function () {
     const testCases = [...cartesian(...Array(4).fill([false, true]))].map(

--- a/static/tests/frontend/utils.js
+++ b/static/tests/frontend/utils.js
@@ -14,10 +14,14 @@ const makeSilentAudioTrack = () => {
   return dst.stream.getAudioTracks()[0];
 };
 
-const makeVideoTrack = () => {
+const makeVideoTrack = (constraints) => {
   const canvas = helper.padChrome$.window.document.createElement('canvas');
-  canvas.width = 160;
-  canvas.height = 120;
+  const {
+    width: {max: widthMax = 160, ideal: widthIdeal} = {},
+    height: {max: heightMax = 120, ideal: heightIdeal} = {},
+  } = constraints;
+  canvas.width = widthIdeal || widthMax;
+  canvas.height = heightIdeal || heightMax;
   const ctx = canvas.getContext('2d');
   ctx.fillStyle = `#${Math.floor(Math.random() * 2 ** 24).toString(16).padStart(6, '0')}`;
   ctx.fillRect(0, 0, canvas.width, canvas.height);
@@ -25,13 +29,12 @@ const makeVideoTrack = () => {
 };
 
 // Creates dummy audio and/or video tracks. Limitations:
-//   - `audio` and `video` are treated as Booleans (video size requirements are ignored).
 //   - Most browsers prohibit audio until there has been some user interaction with the page or
 //     the real getUserMedia() has been called.
 exports.fakeGetUserMedia = async ({audio, video}) => {
   if (!audio && !video) throw new DOMException('either audio or video is required', 'TypeError');
   return new MediaStream([
     ...(audio ? [makeSilentAudioTrack()] : []),
-    ...(video ? [makeVideoTrack()] : []),
+    ...(video ? [makeVideoTrack(video)] : []),
   ]);
 };

--- a/static/tests/frontend/utils.js
+++ b/static/tests/frontend/utils.js
@@ -1,0 +1,7 @@
+'use strict';
+
+// Generator function that yields the Cartesian product of the given iterables.
+exports.cartesian = function* (head, ...tail) {
+  const remainder = tail.length > 0 ? exports.cartesian(...tail) : [[]];
+  for (const r of remainder) for (const h of head) yield [h, ...r];
+};

--- a/static/tests/frontend/utils.js
+++ b/static/tests/frontend/utils.js
@@ -23,8 +23,12 @@ const makeVideoTrack = (constraints) => {
   canvas.width = widthIdeal || widthMax;
   canvas.height = heightIdeal || heightMax;
   const ctx = canvas.getContext('2d');
-  ctx.fillStyle = `#${Math.floor(Math.random() * 2 ** 24).toString(16).padStart(6, '0')}`;
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  // With Safari, HTMLVideoElement.play() hangs until the canvas is updated. Add some animation to
+  // work around it.
+  setInterval(() => {
+    ctx.fillStyle = `#${Math.floor(Math.random() * 2 ** 24).toString(16).padStart(6, '0')}`;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }, 500);
   return canvas.captureStream().getVideoTracks()[0];
 };
 

--- a/static/tests/frontend/utils.js
+++ b/static/tests/frontend/utils.js
@@ -5,3 +5,33 @@ exports.cartesian = function* (head, ...tail) {
   const remainder = tail.length > 0 ? exports.cartesian(...tail) : [[]];
   for (const r of remainder) for (const h of head) yield [h, ...r];
 };
+
+const makeSilentAudioTrack = () => {
+  const ctx = new AudioContext();
+  const oscillator = ctx.createOscillator();
+  const dst = oscillator.connect(ctx.createMediaStreamDestination());
+  oscillator.start();
+  return dst.stream.getAudioTracks()[0];
+};
+
+const makeVideoTrack = () => {
+  const canvas = helper.padChrome$.window.document.createElement('canvas');
+  canvas.width = 160;
+  canvas.height = 120;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = `#${Math.floor(Math.random() * 2 ** 24).toString(16).padStart(6, '0')}`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  return canvas.captureStream().getVideoTracks()[0];
+};
+
+// Creates dummy audio and/or video tracks. Limitations:
+//   - `audio` and `video` are treated as Booleans (video size requirements are ignored).
+//   - Most browsers prohibit audio until there has been some user interaction with the page or
+//     the real getUserMedia() has been called.
+exports.fakeGetUserMedia = async ({audio, video}) => {
+  if (!audio && !video) throw new DOMException('either audio or video is required', 'TypeError');
+  return new MediaStream([
+    ...(audio ? [makeSilentAudioTrack()] : []),
+    ...(video ? [makeVideoTrack()] : []),
+  ]);
+};


### PR DESCRIPTION
Multiple commits:
* tests: Remove undocumented `fake` constraint
* tests: Factor out common `cartesian()` function
* tests: Remove unnecessary `makeVideoTrack()` parameters
* tests: Make the fake stream function match the behavior of `getUserMedia()`
* tests: Increase initialization timeout
* tests: Wait for activation to complete to avoid race conditions
* tests: Delete overly strict `race_conditions.js` timeouts
* tests: Move `fakeGetUserMedia` to `utils.js` for reuse
* tests: Add video constraint support to `fakeGetUserMedia()`
* tests: Animate the dummy video track
* tests: Avoid calling `getUserMedia()` where feasible

cc @packardone 