### PR TITLE
Make videos resizable and other CSS improvements

### DIFF
--- a/static/css/webrtc.css
+++ b/static/css/webrtc.css
@@ -9,9 +9,6 @@
   height: auto;
   overflow: auto;
 }
-@media (min-width: 1000px) {
-  padding: 20px 0;
-}
 
 #rtcbox .video-container {
   align-items: center;

--- a/static/css/webrtc.css
+++ b/static/css/webrtc.css
@@ -106,7 +106,6 @@
   #rtcbox {
     flex-direction: row;
     order: 2;
-    justify-content: start;
     align-items: baseline;
   }
   #rtcbox .video-container:not(:first-child) {

--- a/static/css/webrtc.css
+++ b/static/css/webrtc.css
@@ -25,7 +25,7 @@
 }
 #rtcbox video {
   border-left: 5px solid;
-  box-sizing: border-box;
+  box-sizing: content-box;
   background-color: black;
 }
 #rtcbox .video-container, #rtcbox video {

--- a/static/css/webrtc.css
+++ b/static/css/webrtc.css
@@ -1,5 +1,6 @@
 #rtcbox {
   display: none;
+  flex: 0 1 auto;
   flex-direction: column;
   justify-content: start;
   padding: 0;
@@ -104,7 +105,6 @@
   }
   #rtcbox {
     flex-direction: row;
-    flex-shrink: 0;
     order: 2;
     justify-content: start;
     align-items: baseline;

--- a/static/css/webrtc.css
+++ b/static/css/webrtc.css
@@ -11,6 +11,7 @@
 }
 
 #rtcbox .video-container {
+  flex: 0 0 auto;
   align-items: center;
   background-color: black;
   border: 1px solid black;

--- a/static/css/webrtc.css
+++ b/static/css/webrtc.css
@@ -19,9 +19,12 @@
   border-left: 5px solid;
   box-sizing: content-box;
   display: flex;
+  height: auto;
   justify-content: center;
   min-height: 80px;
+  overflow: hidden;
   position: relative;
+  resize: horizontal;
 }
 #rtcbox .video-container:not(:first-child) {
   margin-top: 5px;
@@ -30,6 +33,7 @@
   box-sizing: content-box;
   background-color: black;
   height: 100%;
+  object-fit: contain;
   width: 100%;
 }
 #rtcbox .video-container, #rtcbox video {

--- a/static/css/webrtc.css
+++ b/static/css/webrtc.css
@@ -14,13 +14,14 @@
 }
 
 #rtcbox .video-container {
+  border-left: 5px solid;
+  box-sizing: content-box;
   position: relative;
 }
 #rtcbox .video-container:not(:first-child) {
   margin-top: 5px;
 }
 #rtcbox video {
-  border-left: 5px solid;
   box-sizing: content-box;
   background-color: black;
 }

--- a/static/css/webrtc.css
+++ b/static/css/webrtc.css
@@ -14,8 +14,13 @@
 }
 
 #rtcbox .video-container {
+  align-items: center;
+  background-color: black;
   border-left: 5px solid;
   box-sizing: content-box;
+  display: flex;
+  justify-content: center;
+  min-height: 80px;
   position: relative;
 }
 #rtcbox .video-container:not(:first-child) {

--- a/static/css/webrtc.css
+++ b/static/css/webrtc.css
@@ -26,7 +26,6 @@
   background-color: black;
 }
 #rtcbox .video-container, #rtcbox video {
-  border-radius: 0 3px 3px 0;
   transition: max-width .3s, max-height .3s, width .3s, height .3s;
 }
 

--- a/static/css/webrtc.css
+++ b/static/css/webrtc.css
@@ -13,10 +13,6 @@
   padding: 20px 0;
 }
 
-#rtcbox .error-msg {
-  padding: 10px;
-  max-width: 120px;
-}
 #rtcbox .video-container {
   position: relative;
 }

--- a/static/css/webrtc.css
+++ b/static/css/webrtc.css
@@ -29,6 +29,8 @@
 #rtcbox video {
   box-sizing: content-box;
   background-color: black;
+  height: 100%;
+  width: 100%;
 }
 #rtcbox .video-container, #rtcbox video {
   transition: max-width .3s, max-height .3s, width .3s, height .3s;

--- a/static/css/webrtc.css
+++ b/static/css/webrtc.css
@@ -16,6 +16,7 @@
 #rtcbox .video-container {
   align-items: center;
   background-color: black;
+  border: 1px solid black;
   border-left: 5px solid;
   box-sizing: content-box;
   display: flex;

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -637,15 +637,13 @@ exports.rtc = new class {
     const $interface = $('<div>')
         .addClass('interface-container')
         .attr('id', `interface_${videoId}`);
-    const $videoContainer = $('<div>')
+    $('#rtcbox').append($('<div>')
         .addClass('video-container')
         .toggleClass('local-user', isLocal)
         .css({'width': size, 'max-height': size})
         .append($('<div>').addClass('user-name'))
         .append($video)
-        .append($interface);
-    if (isLocal) $('#rtcbox').prepend($videoContainer);
-    else $('#rtcbox').append($videoContainer);
+        .append($interface));
     this.updatePeerNameAndColor(this.getUserFromId(userId));
 
     // /////

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -632,8 +632,7 @@ exports.rtc = new class {
     const size = `${this._settings.video.sizes.small}px`;
     const $video = $('<video>')
         .attr({id: videoId, muted: isLocal ? '' : null})
-        .prop('muted', isLocal) // Setting the 'muted' attribute isn't sufficient for some reason.
-        .css({'width': size, 'max-height': size});
+        .prop('muted', isLocal); // Setting the 'muted' attribute isn't sufficient for some reason.
     const $interface = $('<div>')
         .addClass('interface-container')
         .attr('id', `interface_${videoId}`);

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -639,7 +639,7 @@ exports.rtc = new class {
     $('#rtcbox').append($('<div>')
         .addClass('video-container')
         .toggleClass('local-user', isLocal)
-        .css({'width': size, 'max-height': size})
+        .css({width: size})
         .append($('<div>').addClass('user-name'))
         .append($video)
         .append($interface));
@@ -710,8 +710,7 @@ exports.rtc = new class {
                 .attr('title', videoEnlarged ? 'Make video smaller' : 'Make video larger')
                 .toggleClass('large', videoEnlarged);
             const videoSize = `${this._settings.video.sizes[videoEnlarged ? 'large' : 'small']}px`;
-            $video.parent().css({'width': videoSize, 'max-height': videoSize});
-            $video.css({'width': videoSize, 'max-height': videoSize});
+            $video.parent().css({width: videoSize});
           },
         }));
 

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -409,9 +409,9 @@ exports.rtc = new class {
     if (!userInfo) return;
     const {userId, name = html10n.get('pad.userlist.unnamed'), colorId = 0} = userInfo;
     const color = typeof colorId === 'number' ? clientVars.colorPalette[colorId] : colorId;
-    $(`#${getVideoId(userId)}`)
-        .css({'border-color': color})
-        .siblings('.user-name').text(name);
+    const $video = $(`#${getVideoId(userId)}`);
+    $video.parent().css({'border-left-color': color});
+    $video.siblings('.user-name').text(name);
   }
 
   showUserMediaError(err) { // show an error returned from getUserMedia

--- a/static/tests/frontend/specs/interface_buttons.js
+++ b/static/tests/frontend/specs/interface_buttons.js
@@ -52,7 +52,7 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
       // I.e. it has come back a quarter pixel off before.
       const $video = chrome$('video');
       expect(numFromCssSize($video.css('width'))).to.be.within(159, 161);
-      expect(numFromCssSize($video.css('height'))).to.be.within(115, 117);
+      expect(numFromCssSize($video.css('height'))).to.be.within(119, 121);
 
       const $enlargeBtn = chrome$('.enlarge-btn');
       $enlargeBtn.click();
@@ -60,13 +60,13 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
       // Expect it to grow to 260, 190
       await helper.waitForPromise(
           () => (numFromCssSize($video.css('width')) > 259 &&
-                 numFromCssSize($video.css('height')) > 190),
+                 numFromCssSize($video.css('height')) > 194),
           1000);
       $enlargeBtn.click();
       // Expect it to shrink to 160, 116
       await helper.waitForPromise(
           () => (numFromCssSize($video.css('width')) < 161 &&
-                 numFromCssSize($video.css('height')) < 117),
+                 numFromCssSize($video.css('height')) < 121),
           1000);
     });
 


### PR DESCRIPTION
Multiple commits:
* Set video element box-sizing to content-box
* Delete unused `.error-msg` style
* Move colored border to `.video-container`
* Remove nearly imperceptible border radius
* Set a minimum height for `.video-container`
* Draw a small black border around the video
* Delete syntactically invalid `@media` at-rule
* Prevent `.video-container` from shrinking below video size
* Rely on CSS to put the self-view first
* Tweak `#rtcbox` flex growth/shrink
* Delete redundant `justify-content` rule
* Automatically size the video element
* Make videos user-resizable

Fixes #58

cc @packardone 