### PR TITLE
Various fixes

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -3,7 +3,7 @@
 
     "ep_webrtc_error_ssl": "TLS (https) is required to use WebRTC.",
     "ep_webrtc_error_permission": "Failed to get permission to access your camera or microphone.",
-    "ep_webrtc_error_notFound": "Failed to find a camera and/or microphone. Reload the page to retry.",
+    "ep_webrtc_error_notFound": "Failed to access your camera or microphone.",
     "ep_webrtc_error_notReadable": "Sorry, a hardware error occurred that prevented access to your camera and/or microphone:",
     "ep_webrtc_error_otherCantAccess": "Sorry, the browser doesn't have access to your camera and/or microphone. Please check permissions in your browser's settings. This is most likely not a hardware error:",
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -708,16 +708,16 @@ exports.rtc = new class {
         .on(audioHardDisabled ? {} : {
           click: (event) => {
             $video.removeData('automuted');
-            // Do not use `await` when calling unmuteAutoMuted() because unmuting is best-effort
-            // (success of this handler does not depend on the ability to unmute). Call
-            // unmuteAutoMuted() early so that the browser can work on unmuting the video in
-            // parallel with the rest of this handler.
-            this.unmuteAutoMuted();
             const muted = isLocal ? this.toggleMuted() : ($video[0].muted = !$video[0].muted);
             _debug(`audio button clicked to ${muted ? 'dis' : 'en'}able audio`);
             $(event.currentTarget)
                 .attr('title', muted ? 'Unmute' : 'Mute')
                 .toggleClass('muted', muted);
+            // Do not use `await` when calling unmuteAutoMuted() because unmuting is best-effort
+            // (success of this handler does not depend on the ability to unmute). Call
+            // unmuteAutoMuted() late so that it can call $video[0].play() after $video[0].muted is
+            // set to its new value, and so that it can auto-mute if necessary.
+            this.unmuteAutoMuted();
           },
         }));
 
@@ -734,13 +734,13 @@ exports.rtc = new class {
           .toggleClass('disallowed', videoHardDisabled)
           .on(videoHardDisabled ? {} : {
             click: (event) => {
-              // Don't use `await` here -- see the comment for the audio button click handler above.
-              this.unmuteAutoMuted();
               const videoEnabled = !this.toggleVideo();
               _debug(`video button clicked to ${videoEnabled ? 'en' : 'dis'}able video`);
               $(event.currentTarget)
                   .attr('title', videoEnabled ? 'Disable video' : 'Enable video')
                   .toggleClass('off', !videoEnabled);
+              // Don't use `await` here -- see the comment for the audio button click handler above.
+              this.unmuteAutoMuted();
             },
           }));
     }
@@ -755,14 +755,14 @@ exports.rtc = new class {
         .attr('title', 'Make video larger')
         .on({
           click: (event) => {
-            // Don't use `await` here -- see the comment for the audio button click handler above.
-            this.unmuteAutoMuted();
             videoEnlarged = !videoEnlarged;
             $(event.currentTarget)
                 .attr('title', videoEnlarged ? 'Make video smaller' : 'Make video larger')
                 .toggleClass('large', videoEnlarged);
             const videoSize = `${this._settings.video.sizes[videoEnlarged ? 'large' : 'small']}px`;
             $video.parent().css({width: videoSize});
+            // Don't use `await` here -- see the comment for the audio button click handler above.
+            this.unmuteAutoMuted();
           },
         }));
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -35,9 +35,9 @@ class LocalTracks extends EventTarget {
     newTrack = newTrack || null; // Convert undefined to null.
     let oldTrack = null;
     const tracks =
-          kind === 'audio' ? this.stream.getAudioTracks()
-          : kind === 'video' ? this.stream.getVideoTracks()
-          : this.stream.getTracks();
+        kind === 'audio' ? this.stream.getAudioTracks()
+        : kind === 'video' ? this.stream.getVideoTracks()
+        : this.stream.getTracks();
     for (const track of tracks) {
       if (track.kind !== kind) continue;
       if (track === newTrack) return; // No change.

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -28,7 +28,6 @@ class LocalTracks extends EventTarget {
   constructor() {
     super();
     Object.defineProperty(this, 'stream', {value: new MediaStream(), writeable: false});
-    this._tracks = new Map();
   }
 
   setTrack(kind, newTrack) {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -193,6 +193,14 @@ class PeerState extends EventTarget {
         case 'failed': pc.restartIce(); break;
       }
     });
+    // RTCPeerConnection.peerIdentity is mentioned in https://www.w3.org/TR/webrtc-identity/ but as
+    // of 2021-06-24 only Firefox supports it.
+    if (pc.peerIdentity != null) {
+      // Silence "InvalidStateError: RTCPeerConnection is gone (did you enter Offline mode?)"
+      // unhandled Promise rejection errors in Firefox. This can happen if Firefox drops the
+      // connection because the pad is in an idle/background tab.
+      pc.peerIdentity.catch((err) => this._debug('Failed to assert peer identity:', err));
+    }
 
     if (this._pc != null) this._pc.close();
     this._pc = pc;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -635,12 +635,18 @@ exports.rtc = new class {
   // autoplay). If unmuting a video fails (perhaps the browser still thinks we're trying to
   // autoplay), the video is auto-muted again.
   async unmuteAutoMuted() {
-    await Promise.all($('#rtcbox video').map(async (i, video) => {
-      const $video = $(video);
-      if (!$video.data('automuted')) return;
-      $(`#interface_${$video.attr('id')} .audio-btn`).click();
-      await this.playVideo($video);
-    }).get());
+    if (this._unmuteAutoMutedInProgress) return; // Prevent infinite recursion if unmuting fails.
+    this._unmuteAutoMutedInProgress = true;
+    try {
+      await Promise.all($('#rtcbox video').map(async (i, video) => {
+        const $video = $(video);
+        if (!$video.data('automuted')) return;
+        $(`#interface_${$video.attr('id')} .audio-btn`).click();
+        await this.playVideo($video);
+      }).get());
+    } finally {
+      this._unmuteAutoMutedInProgress = false;
+    }
   }
 
   addInterface(userId, isLocal) {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -437,6 +437,10 @@ exports.rtc = new class {
           this.sendErrorStat('SecureConnection');
         }
         break;
+      case 'OverconstrainedError':
+        debug(err);
+        // Safari v14.1 on macOS v11.13.1 (Big Sur) on Sauce Labs emits OverconstrainedError when it
+        // can't find a camera. Fall through to the NotFoundError case:
       case 'NotFoundError':
         reason = html10n.get('ep_webrtc_error_notFound');
         this.sendErrorStat('NotFound');

--- a/static/tests/frontend/specs/errors.js
+++ b/static/tests/frontend/specs/errors.js
@@ -9,7 +9,7 @@ describe('error handling', function () {
     // Hard to test the version of NotAllowedError that is the SSL error
     // because it requires changing window.location
     ['NotAllowedError', 'Failed to get permission to access'],
-    ['NotFoundError', 'Failed to find a camera'],
+    ['NotFoundError', 'Failed to access'],
     ['NotReadableError', 'hardware error occurred'],
     ['AbortError', 'not a hardware error'],
   ];

--- a/static/tests/frontend/specs/race_conditions.js
+++ b/static/tests/frontend/specs/race_conditions.js
@@ -43,7 +43,7 @@ describe('Race conditions that leave audio/video track enabled', function () {
       expect(originalVideoTrack).to.equal(videoTrack);
       expect(chrome$('.video-btn').hasClass('off')).to.equal(!videoTrack.enabled);
 
-      chrome$.window.ep_webrtc.deactivate();
+      await chrome$.window.ep_webrtc.deactivate();
       chrome$('.audio-btn').click();
       chrome$('.video-btn').click();
       await chrome$.window.ep_webrtc.activate();
@@ -79,7 +79,7 @@ describe('Race conditions that leave audio/video track enabled', function () {
 
       chrome$('.audio-btn').click();
       chrome$('.video-btn').click();
-      chrome$.window.ep_webrtc.deactivate();
+      await chrome$.window.ep_webrtc.deactivate();
       await chrome$.window.ep_webrtc.activate();
 
       // getUserMedia should give us new audio and video Tracks and disable the old one
@@ -112,7 +112,7 @@ describe('Race conditions that leave audio/video track enabled', function () {
       expect(originalVideoTrack).to.equal(videoTrack);
       expect(chrome$('.video-btn').hasClass('off')).to.equal(!videoTrack.enabled);
 
-      chrome$.window.ep_webrtc.deactivate();
+      await chrome$.window.ep_webrtc.deactivate();
       const p = chrome$.window.ep_webrtc.activate();
       await helper.waitForPromise(
           () => chrome$ && chrome$('.interface-container').length === 1, 2000);
@@ -152,7 +152,7 @@ describe('Race conditions that leave audio/video track enabled', function () {
       expect(originalVideoTrack).to.equal(videoTrack);
       expect(chrome$('.video-btn').hasClass('off')).to.equal(!videoTrack.enabled);
 
-      chrome$.window.ep_webrtc.deactivate();
+      await chrome$.window.ep_webrtc.deactivate();
       const p = chrome$.window.ep_webrtc.activate();
       chrome$('.audio-btn').click();
       chrome$('.video-btn').click();


### PR DESCRIPTION
Multiple commits:
* Fix indentation
* Add more debug messages
* Delete unused `_tracks` variable
* Join concurrent `activate()`/`deactivate()` calls
* Treat OverconstrainedError like NotFoundError
* Prevent recursion during auto-unmute
* Silence `peerIdentity` rejections
* Fix handling of changed peer session and instance IDs
* Call `unmuteAutoMuted()` at the end of the click handler

cc @packardone 