### PR TITLE
test improvements (and prerequisite refactoring)

### DIFF
--- a/static/tests/frontend/specs/interface_buttons.js
+++ b/static/tests/frontend/specs/interface_buttons.js
@@ -51,8 +51,11 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
       // All of these sizes have to allow for tolerances.
       // I.e. it has come back a quarter pixel off before.
       const $video = chrome$('video');
-      expect(numFromCssSize($video.css('width'))).to.be.within(159, 161);
-      expect(numFromCssSize($video.css('height'))).to.be.within(119, 121);
+      await helper.waitForPromise(() => {
+        const w = numFromCssSize($video.css('width'));
+        const h = numFromCssSize($video.css('height'));
+        return 159 < w && w < 161 && 119 < h && h < 121;
+      });
 
       const $enlargeBtn = chrome$('.enlarge-btn');
       $enlargeBtn.click();

--- a/static/tests/frontend/utils.js
+++ b/static/tests/frontend/utils.js
@@ -23,9 +23,10 @@ const makeVideoTrack = (constraints) => {
   canvas.width = widthIdeal || widthMax;
   canvas.height = heightIdeal || heightMax;
   const ctx = canvas.getContext('2d');
-  // With Safari, HTMLVideoElement.play() hangs until the canvas is updated. Add some animation to
-  // work around it.
-  setInterval(() => {
+  // Some animation is needed because in some browsers HTMLVideoElement.play() will hang until the
+  // canvas is updated. The pad's window.setInterval is called in the hopes that the interval will
+  // be automatically stopped once the pad is unloaded.
+  helper.padChrome$.window.setInterval(() => {
     ctx.fillStyle = `#${Math.floor(Math.random() * 2 ** 24).toString(16).padStart(6, '0')}`;
     ctx.fillRect(0, 0, canvas.width, canvas.height);
   }, 500);

--- a/static/tests/frontend/utils.js
+++ b/static/tests/frontend/utils.js
@@ -29,7 +29,7 @@ const makeVideoTrack = (constraints) => {
   helper.padChrome$.window.setInterval(() => {
     ctx.fillStyle = `#${Math.floor(Math.random() * 2 ** 24).toString(16).padStart(6, '0')}`;
     ctx.fillRect(0, 0, canvas.width, canvas.height);
-  }, 500);
+  }, 100); // Use a relatively high frame rate to speed up tests.
   return canvas.captureStream().getVideoTracks()[0];
 };
 

--- a/static/tests/frontend/utils.js
+++ b/static/tests/frontend/utils.js
@@ -8,9 +8,8 @@ exports.cartesian = function* (head, ...tail) {
 
 const makeSilentAudioTrack = () => {
   const ctx = new AudioContext();
-  const oscillator = ctx.createOscillator();
-  const dst = oscillator.connect(ctx.createMediaStreamDestination());
-  oscillator.start();
+  const gain = ctx.createGain();
+  const dst = gain.connect(ctx.createMediaStreamDestination());
   return dst.stream.getAudioTracks()[0];
 };
 


### PR DESCRIPTION
Multiple commits:
* Make all local track modifications in `updateLocalTracks()`
* Keep track of when the click handlers are busy
* tests: Redo `race_conditions.js` tests
* tests: Use the pad's `setInterval` for the animation loop
* tests: Increase frame rate to speed up tests
* tests: Actually generate silence from `makeSilentAudioTrack()`
* tests: Fix `interface_buttons.js` race on Safari

cc @packardone 
