### PR TITLE
More UX improvements

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -692,6 +692,8 @@ exports.rtc = new class {
         debug('auto-muting video', $video[0]);
         // The self view is always muted, so this click() only applies to videos of remote peers.
         $(`#interface_${$video.attr('id')} .audio-btn`).click();
+        // Prevent infinite recursion if clicking the audio button didn't mute.
+        if (!$video[0].muted) throw new Error('assertion failed: video element should be muted');
         $video.data('automuted', true);
         return await this.playVideo($video);
       }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -681,10 +681,6 @@ exports.rtc = new class {
       return await $video[0].play();
     } catch (err) {
       debug('failed to play video', $video[0], err);
-      // AbortError can happen if there is a hangup (e.g., the user disables WebRTC) while playback
-      // is starting. The video element will be deleted shortly (if it hasn't already been deleted)
-      // so it's OK to ignore the error.
-      if (err.name === 'AbortError') return;
       // Browsers won't allow autoplayed video with sound until the user has interacted with the
       // page or the page is already capturing audio or video. If playback is not permitted, mute
       // the video and try again.
@@ -697,7 +693,13 @@ exports.rtc = new class {
         $video.data('automuted', true);
         return await this.playVideo($video);
       }
-      throw err;
+      // The error is most likely a browser autoplay restriction. It's not useful to display such
+      // errors -- or really any other play error for that matter -- in a gritter box, so ignore the
+      // error. The video won't be playing, but that's not a big deal: The user can click on one of
+      // the interface buttons to try playing again (via unmuteAndPlayAll()).
+      //
+      // TODO: Indicate the error in the video element (e.g., red circle with an exclamation point
+      // that displays the error message when clicked or hovered over).
     }
   }
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -529,9 +529,10 @@ exports.rtc = new class {
       const $audioBtn = $interface.find('.audio-btn');
       const $videoBtn = $interface.find('.video-btn');
       const addAudioTrack = updateAudio && !$audioBtn.hasClass('muted') &&
-          !this._localTracks.stream.getAudioTracks().some((t) => t !== this._disabledSilence);
+          !this._localTracks.stream.getAudioTracks().some(
+              (t) => t !== this._disabledSilence && t.readyState === 'live');
       const addVideoTrack = updateVideo && !$videoBtn.hasClass('off') &&
-          this._localTracks.stream.getVideoTracks().length === 0;
+          !this._localTracks.stream.getVideoTracks().some((t) => t.readyState === 'live');
       if (addAudioTrack || addVideoTrack) {
         debug(`requesting permission to access ${
           addAudioTrack && addVideoTrack ? 'camera and microphone'
@@ -559,7 +560,8 @@ exports.rtc = new class {
           // getUserMedia() was running.
           track.enabled = track !== this._disabledSilence && !$audioBtn.hasClass('muted');
         }
-        const hasAudio = this._localTracks.stream.getAudioTracks().some((t) => t.enabled);
+        const hasAudio = this._localTracks.stream.getAudioTracks().some(
+            (t) => t.enabled && t.readyState === 'live');
         $audioBtn
             .attr('title', hasAudio ? 'Mute' : 'Unmute')
             .toggleClass('muted', !hasAudio);
@@ -570,7 +572,8 @@ exports.rtc = new class {
           // getUserMedia() was running.
           track.enabled = !$videoBtn.hasClass('off');
         }
-        const hasVideo = this._localTracks.stream.getVideoTracks().some((t) => t.enabled);
+        const hasVideo = this._localTracks.stream.getVideoTracks().some(
+            (t) => t.enabled && t.readyState === 'live');
         $videoBtn
             .attr('title', hasVideo ? 'Disable video' : 'Enable video')
             .toggleClass('off', !hasVideo);

--- a/static/tests/frontend/specs/errors.js
+++ b/static/tests/frontend/specs/errors.js
@@ -1,8 +1,8 @@
 'use strict';
 
 describe('error handling', function () {
-  let enable;
   let chrome$;
+  let $videoBtn;
   let getUserMediaBackup;
 
   const testCases = [
@@ -16,10 +16,17 @@ describe('error handling', function () {
 
   before(async function () {
     this.timeout(60000);
-    await helper.aNewPad({params: {av: false}});
+    await helper.aNewPad({params: {
+      av: true,
+      webrtcaudioenabled: false,
+      webrtcvideoenabled: false,
+    }});
     chrome$ = helper.padChrome$;
     await helper.waitForPromise(() => chrome$('#rtcbox').data('initialized'));
-    enable = chrome$('#options-enablertc');
+    const ownUserId = chrome$.window.ep_webrtc.getUserId();
+    const ownVideoId = `video_${ownUserId.replace(/\./g, '_')}`;
+    const ownInterfaceId = `interface_${ownVideoId}`;
+    $videoBtn = chrome$(`#${ownInterfaceId} .video-btn`);
     getUserMediaBackup = chrome$.window.navigator.mediaDevices.getUserMedia;
   });
 
@@ -31,7 +38,7 @@ describe('error handling', function () {
     // No idea why but this needs to be called twice to actually make #gritter-container hidden
     chrome$.gritter.removeAll({fade: false});
     chrome$.gritter.removeAll({fade: false});
-    expect(enable.prop('checked')).to.equal(false);
+    expect($videoBtn.hasClass('off')).to.equal(true);
   });
 
   for (const [errName, checkString] of testCases) {
@@ -42,7 +49,7 @@ describe('error handling', function () {
         throw err;
       };
       await helper.waitForPromise(() => chrome$('#gritter-container:visible').length === 0, 1000);
-      enable.click();
+      $videoBtn.click();
       await helper.waitForPromise(() => chrome$('#gritter-container:visible').length === 1, 1000);
       expect(chrome$('.gritter-title').html()).to.be('Error');
       expect(chrome$('.gritter-content p').html()).to.contain(checkString);

--- a/static/tests/frontend/specs/interface_buttons.js
+++ b/static/tests/frontend/specs/interface_buttons.js
@@ -142,7 +142,7 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
 
       const chrome$ = helper.padChrome$;
 
-      expect(audioTrack.enabled).to.be(false);
+      expect(audioTrack).to.be(null);
       expect(chrome$('.audio-btn.muted').length).to.be(1);
       expect(chrome$('.audio-btn').attr('title')).to.be('Unmute');
 
@@ -150,7 +150,9 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
       $audioBtn.click();
 
       await helper.waitForPromise(
-          () => chrome$('.audio-btn.muted').length === 0 && audioTrack.enabled === true, 3000);
+          () => (chrome$('.audio-btn.muted').length === 0 &&
+                 audioTrack != null && audioTrack.enabled),
+          3000);
       expect(chrome$('.audio-btn').attr('title')).to.be('Mute');
       $audioBtn.click();
       await helper.waitForPromise(
@@ -163,9 +165,7 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
 
       const chrome$ = helper.padChrome$;
 
-      await helper.waitForPromise(
-          () => chrome$('.video-btn').length === 1 && videoTrack != null, 3000);
-      expect(videoTrack.enabled).to.be(false);
+      expect(videoTrack).to.be(null);
       expect(chrome$('.video-btn.off').length).to.be(1);
       expect(chrome$('.video-btn').attr('title')).to.contain('Enable');
 
@@ -173,7 +173,9 @@ describe('Test the behavior of the interface buttons: Mute, Video Disable, Enlar
       $videoBtn.click();
 
       await helper.waitForPromise(
-          () => chrome$('.video-btn.off').length === 0 && videoTrack.enabled === true, 3000);
+          () => (chrome$('.video-btn.off').length === 0 &&
+                 videoTrack != null && videoTrack.enabled),
+          3000);
       expect(chrome$('.video-btn').attr('title')).to.contain('Disable');
       $videoBtn.click();
       await helper.waitForPromise(


### PR DESCRIPTION
Multiple commits:
* Defer `getMedia()` call until the user enables the camera/microphone
* Warm up RTC connections with a dummy track
* Ignore ended local media tracks
* Factor out self-view button DOM manipulations
* Stop streaming local tracks that have ended
* Update the self-view UI if the browser ends a local track
* Also try playing videos when auto-unmuting
* Add a sanity check to prevent infinite recursion when auto-muting
* Ignore `HTMLVideoElement.play()` errors

cc @packardone 