### PR TITLE
Improve error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ const settings = {
   },
   iceServers: [{urls: ['stun:stun.l.google.com:19302']}],
   listenClass: null,
+  moreInfoUrl: {},
 };
 let socketio;
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -2,8 +2,12 @@
     "ep_webrtc_settings_enablertc": "Enable Audio/Video Chat",
 
     "ep_webrtc_error_ssl": "TLS (https) is required to use WebRTC.",
-    "ep_webrtc_error_permission": "Failed to get permission to access your camera or microphone.",
-    "ep_webrtc_error_notFound": "Failed to access your camera or microphone.",
+    "ep_webrtc_error_permission_cam": "Failed to get permission to access your camera.",
+    "ep_webrtc_error_permission_mic": "Failed to get permission to access your microphone.",
+    "ep_webrtc_error_permission_cammic": "Failed to get permission to access your camera and microphone.",
+    "ep_webrtc_error_notFound_cam": "Failed to access your camera.",
+    "ep_webrtc_error_notFound_mic": "Failed to access your microphone.",
+    "ep_webrtc_error_notFound_cammic": "Failed to access your camera and microphone.",
     "ep_webrtc_error_notReadable": "Sorry, a hardware error occurred that prevented access to your camera and/or microphone:",
     "ep_webrtc_error_otherCantAccess": "Sorry, the browser doesn't have access to your camera and/or microphone. Please check permissions in your browser's settings. This is most likely not a hardware error:",
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -83,6 +83,7 @@
   bottom: 0px;
   left: 0px;
   padding: 5px;
+  width: 100%;
   z-index: 2;
 }
 #rtcbox .interface-btn {
@@ -103,6 +104,16 @@
 
 #rtcbox .interface-btn.enlarge-btn:before { content: '\e840'; }
 #rtcbox .interface-btn.enlarge-btn.large:before { content: '\e83f'; }
+
+#rtcbox .video-container .interface-container .interface-btn.error-btn {
+  --interface-background-alpha: 1.0;
+  --interface-text-alpha: 1.0;
+  --interface-text-color-rgb: 255, 0, 0;
+}
+#rtcbox .video-container .interface-container .interface-btn.error-btn:before {
+  content: "\f071";
+  font-family: "fontawesome-ep_webrtc";
+}
 
 #rtcbox .video-container .resize-handle {
   --handle-size: 15px;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -700,6 +700,8 @@ exports.rtc = new class {
     try {
       await $video[0].play();
       debug('video is playing', $video[0]);
+      $videoContainer.find('.automuted-error-btn')
+          .css({display: $video.data('automuted') ? '' : 'none'});
       $playErrorBtn.css({display: 'none'});
     } catch (err) {
       debug('failed to play video', $video[0], err);
@@ -936,6 +938,11 @@ exports.rtc = new class {
     // TODO: These should be converted into accessible popovers/toggletips that work on touch-only
     // devices. See: https://inclusive-components.design/tooltips-toggletips/
     const errorBtns = [
+      {
+        cls: 'automuted-error-btn',
+        title: 'Your browser blocked audio playback. Click to unmute.',
+        click: () => this.unmuteAndPlayAll(),
+      },
       {
         cls: 'play-error-btn',
         title: 'Playback failed. Click to retry.',

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -548,6 +548,12 @@ exports.rtc = new class {
         // Let Etherpad's error handling handle the error.
         throw err;
     }
+    const moreInfoUrl = this._settings.moreInfoUrl[msgId];
+    if (moreInfoUrl) {
+      extraInfo.append($('<p>').append($('<a>')
+          .attr({href: moreInfoUrl, target: '_blank', rel: 'noopener noreferrer'})
+          .text('Click here for more information.')));
+    }
     $.gritter.add({
       title: 'Error',
       text: $(document.createDocumentFragment())


### PR DESCRIPTION
Multiple commits:
* Display an error icon if `.play()` fails
* Display an error icon if audio is auto-muted
* Display an error icon if the peer's connection is lost
* Display an error icon if the local audio or video track ends
* Refactor `showUserMediaError()`
* Add configurable URLs for more information
* Show specific device(s) in error messages

cc @packardone 