### PR TITLE
Fix logging of `play()` and `getUserMedia()` errors

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -512,13 +512,15 @@ exports.rtc = new class {
       msg = `${err.name}: ${msg}`;
     }
     $.post('../jserror', {
-      type: 'Plugin ep_screenrtc',
-      msg,
-      url: window.location.href,
-      source: fileName,
-      linenumber: lineNumber,
-      userAgent: navigator.userAgent,
-      stack: err.stack,
+      errorInfo: JSON.stringify({
+        type: 'Plugin ep_screenrtc',
+        msg,
+        url: window.location.href,
+        source: fileName,
+        linenumber: lineNumber,
+        userAgent: navigator.userAgent,
+        stack: err.stack,
+      }),
     });
   }
 


### PR DESCRIPTION
Before this change the errors weren't actually logged. That's what I get for hastily tossing together something without thorough testing.

cc @packardone 