### PR TITLE
Retry when clicking "local audio/video stopped unexpectedly" alert

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1013,11 +1013,6 @@ exports.rtc = new class {
     // devices. See: https://inclusive-components.design/tooltips-toggletips/
     const errorBtns = [
       {
-        cls: 'audioended-error-btn',
-        title: 'Audio stopped unexpectedly. Click to clear this notification.',
-        click: (ev) => $(ev.currentTarget).css({display: 'none'}),
-      },
-      {
         cls: 'automuted-error-btn',
         title: 'Your browser blocked audio playback. Click to unmute.',
         click: () => this.unmuteAndPlayAll(),
@@ -1032,11 +1027,18 @@ exports.rtc = new class {
         title: 'Playback failed. Click to retry.',
         click: () => this.unmuteAndPlayAll(),
       },
-      {
-        cls: 'videoended-error-btn',
-        title: 'Video stopped unexpectedly. Click to clear this notification.',
-        click: (ev) => $(ev.currentTarget).css({display: 'none'}),
-      },
+      ...(isLocal ? [
+        {
+          cls: 'audioended-error-btn',
+          title: 'Audio stopped unexpectedly. Click to clear this notification.',
+          click: (ev) => $(ev.currentTarget).css({display: 'none'}),
+        },
+        {
+          cls: 'videoended-error-btn',
+          title: 'Video stopped unexpectedly. Click to clear this notification.',
+          click: (ev) => $(ev.currentTarget).css({display: 'none'}),
+        },
+      ] : []),
     ];
     for (const {cls, title, click} of errorBtns) {
       $interface.append($('<span>')

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -928,9 +928,9 @@ exports.rtc = new class {
     // Disable Video button
     // /////
 
+    let $videoBtn;
     if (isLocal) {
-      const $videoBtn =
-          $('<span>').addClass('interface-btn video-btn buttonicon').appendTo($interface);
+      $videoBtn = $('<span>').addClass('interface-btn video-btn buttonicon').appendTo($interface);
       this._selfViewButtons.video = {
         get enabled() { return !$videoBtn.hasClass('off'); },
         set enabled(val) {
@@ -1030,13 +1030,13 @@ exports.rtc = new class {
       ...(isLocal ? [
         {
           cls: 'audioended-error-btn',
-          title: 'Audio stopped unexpectedly. Click to clear this notification.',
-          click: (ev) => $(ev.currentTarget).css({display: 'none'}),
+          title: 'Audio stopped unexpectedly. Click to retry.',
+          click: () => $audioBtn.click(),
         },
         {
           cls: 'videoended-error-btn',
-          title: 'Video stopped unexpectedly. Click to clear this notification.',
-          click: (ev) => $(ev.currentTarget).css({display: 'none'}),
+          title: 'Video stopped unexpectedly. Click to retry.',
+          click: () => $videoBtn.click(),
         },
       ] : []),
     ];


### PR DESCRIPTION
This should improve UX if the track ended due to a temporary condition.

cc @packardone