### PR TITLE
Reduce error log spam

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -309,7 +309,7 @@ class PeerState extends EventTargetPolyfill {
   }
 
   async receiveMessage({ids, candidate, description, hangup}) {
-    if (this._closed) throw new Error('Unable to process message because PeerState is closed');
+    if (this._closed) return debug('Ignoring message because PeerState is closed');
     if (hangup != null) {
       this.close(true);
       return;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -146,7 +146,7 @@ class PeerState extends EventTargetPolyfill {
     this._onremovetrack =
         () => { if (this._remoteStream.getTracks().length === 0) this._setRemoteStream(null); };
     this._ontrackchanged = async ({oldTrack, newTrack}) => {
-      if (this._pc == null) return;
+      if (this._pc == null || this._pc.connectionState === 'closed') return;
       this._debug(`replacing ${oldTrack ? oldTrack.kind : newTrack.kind} track ` +
                   `${oldTrack ? oldTrack.id : '(null)'} with ` +
                   `${newTrack ? newTrack.id : '(null)'}`);


### PR DESCRIPTION
Multiple commits:
* Check if PC is closed when local track changes
* Convert an exception into a debug message
* Defer logging disconnect until after `userLeave` hook fires
* Defer logging errors in case they are caused by navigating away

cc @packardone 