### PR TITLE
Switch video constraints from `max` to `ideal`

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -654,7 +654,7 @@ exports.rtc = new class {
         try {
           stream = await window.navigator.mediaDevices.getUserMedia({
             audio: addAudioTrack,
-            video: addVideoTrack && {width: {max: 320}, height: {max: 240}},
+            video: addVideoTrack && {width: {ideal: 320}, height: {ideal: 240}},
           });
           debug('successfully accessed device(s)');
         } catch (err) {


### PR DESCRIPTION
There's no good reason to fail if the browser is unable to get a camera stream smaller than 320x240. Some browsers might have a hard time getting a stream smaller than 320x240 if the camera is in portrait mode.

cc @packardone 