### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Publish Status](https://github.com/ether/ep_webrtc/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_webrtc/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_webrtc/actions/workflows/test-and-release.yml)
 
-# ep_webrtc
+# WebRTC Audio / Video for Etherpad
 
 WebRTC-based audio/video chat and screen sharing with other users visiting the
 same pad.


### PR DESCRIPTION
Replace the placeholder `ep_webrtc` heading in README.md with "WebRTC Audio / Video for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.