### PR TITLE
fix: restore camera when screen-picker is canceled

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1061,12 +1061,28 @@ exports.rtc = new class {
         click: async () => {
           const screenshareEnabled = !this._selfViewButtons.screenshare.enabled;
           _debug(`button clicked to ${screenshareEnabled ? 'en' : 'dis'}able screen sharing`);
+          // Capture the previous camera state so we can restore it if
+          // the screen-picker is canceled (getDisplayMedia rejects).
+          // Without this, clicking screenshare → cancel turns the
+          // camera off permanently from the user's perspective and
+          // leaves a stale disabled camera track in the local stream.
+          const wasCameraOn = this._selfViewButtons.video.enabled;
           // Unconditionally disable the camera. Either screen sharing was previously disabled in
           // which case the user now wants to share the screen, or screen sharing was previously
           // enabled in which case the user wants to shut off all video.
           this._selfViewButtons.video.enabled = false;
           this._selfViewButtons.screenshare.enabled = screenshareEnabled;
           await this.updateLocalTracks({updateVideo: true});
+          // If the user wanted to start screensharing but the picker
+          // was canceled or denied, updateLocalTracks has flipped
+          // screenshare.enabled back to false. Bring the camera back
+          // to the state it was in before the click so the user isn't
+          // left with no video at all.
+          if (screenshareEnabled && wasCameraOn &&
+              !this._selfViewButtons.screenshare.enabled) {
+            this._selfViewButtons.video.enabled = true;
+            await this.updateLocalTracks({updateVideo: true});
+          }
           // Don't use `await` here -- see the comment for the audio button click handler above.
           this.unmuteAndPlayAll();
         },

--- a/static/tests/frontend-new/specs/screenshare.spec.ts
+++ b/static/tests/frontend-new/specs/screenshare.spec.ts
@@ -1,0 +1,106 @@
+import {expect, test} from '@playwright/test';
+import {goToNewPadWithParams, installFakeGetUserMedia, setPadPrefsCookie} from '../helper/utils';
+
+test.describe('screen share button', () => {
+  test.beforeEach(async ({page, context}) => {
+    test.setTimeout(60_000);
+    await context.clearCookies();
+    await setPadPrefsCookie(page, {
+      rtcEnabled: false,
+      audioEnabledOnStart: false,
+      videoEnabledOnStart: true,
+    });
+    await goToNewPadWithParams(page, {});
+    await installFakeGetUserMedia(page);
+    // Stub getDisplayMedia onto navigator.mediaDevices so the
+    // screenshare-btn doesn't get hidden by addInterface (it checks
+    // typeof navigator.mediaDevices.getDisplayMedia === 'function').
+    // Tests below override this stub per-case to control behavior.
+    await page.evaluate(() => {
+      const w = window as any;
+      w.__getDisplayMediaCallCount = 0;
+      w.navigator.mediaDevices.getDisplayMedia = async () => {
+        w.__getDisplayMediaCallCount++;
+        const err: any = new Error('user cancelled the picker');
+        err.name = 'NotAllowedError';
+        throw err;
+      };
+    });
+    await page.evaluate(() => (window as any).ep_webrtc.activate());
+    await page.waitForFunction(
+        () => (window as any).$('#rtcbox').data('initialized'));
+    // Confirm the starting state: camera on, screenshare off.
+    await page.waitForFunction(() => {
+      const w = window as any;
+      const videoBtn = w.$('.video-btn');
+      const ssBtn = w.$('.screenshare-btn');
+      return videoBtn.length === 1 && !videoBtn.hasClass('off') &&
+             ssBtn.length === 1 && ssBtn.hasClass('off');
+    }, undefined, {timeout: 5000});
+  });
+
+  test('canceling the screen-picker restores the camera', async ({page}) => {
+    // Click the screenshare button. Our stubbed getDisplayMedia
+    // rejects with NotAllowedError (the same error Chrome dispatches
+    // when the user clicks Cancel in the picker).
+    await page.evaluate(() => (window as any).$('.screenshare-btn').click());
+    await page.evaluate(
+        () => (window as any).$('.screenshare-btn').data('idle')('click'));
+    // The picker really fired.
+    const callCount = await page.evaluate(
+        () => (window as any).__getDisplayMediaCallCount);
+    expect(callCount).toBeGreaterThanOrEqual(1);
+    // Final state: camera is back on, screenshare is off.
+    const finalState = await page.evaluate(() => {
+      const w = window as any;
+      const videoBtn = w.$('.video-btn');
+      const ssBtn = w.$('.screenshare-btn');
+      return {
+        videoOff: videoBtn.hasClass('off'),
+        screenshareOff: ssBtn.hasClass('off'),
+      };
+    });
+    expect(finalState).toEqual({videoOff: false, screenshareOff: true});
+    // And there's a live, enabled video track in the local stream so
+    // the user actually sees their camera again (not just a button
+    // toggled on with no underlying media).
+    const trackState = await page.evaluate(() => {
+      const w = window as any;
+      const v = document.querySelector('video') as HTMLVideoElement | null;
+      const stream = v && (v.srcObject as MediaStream | null);
+      const t = stream && stream.getVideoTracks()[0];
+      return t == null ? null : {enabled: t.enabled, readyState: t.readyState};
+    });
+    expect(trackState).toEqual({enabled: true, readyState: 'live'});
+  });
+
+  test('canceling screen-picker when camera was off leaves both off', async ({page}) => {
+    // Turn camera off first.
+    await page.evaluate(() => (window as any).$('.video-btn').click());
+    await page.evaluate(
+        () => (window as any).$('.video-btn').data('idle')('click'));
+    // Sanity-check both buttons off, no live enabled video track.
+    const before = await page.evaluate(() => {
+      const w = window as any;
+      return {
+        videoOff: w.$('.video-btn').hasClass('off'),
+        screenshareOff: w.$('.screenshare-btn').hasClass('off'),
+      };
+    });
+    expect(before).toEqual({videoOff: true, screenshareOff: true});
+    // Click screenshare → cancel.
+    await page.evaluate(() => (window as any).$('.screenshare-btn').click());
+    await page.evaluate(
+        () => (window as any).$('.screenshare-btn').data('idle')('click'));
+    // Both should remain off (don't auto-enable the camera the user
+    // had explicitly turned off).
+    const after = await page.evaluate(() => {
+      const w = window as any;
+      return {
+        videoOff: w.$('.video-btn').hasClass('off'),
+        screenshareOff: w.$('.screenshare-btn').hasClass('off'),
+      };
+    });
+    expect(after).toEqual({videoOff: true, screenshareOff: true});
+  });
+});


### PR DESCRIPTION
## Summary

Clicking the screenshare button when the camera is on, then clicking Cancel in the OS screen-picker, used to leave the user with no video at all (camera button stuck off, stale disabled camera track in the local stream).

## Bug

`addAsyncEventHandlers($screenshareBtn, ...)` in `static/js/index.js` did:

```js
this._selfViewButtons.video.enabled = false;            // turn camera button off
this._selfViewButtons.screenshare.enabled = true;
await this.updateLocalTracks({updateVideo: true});      // calls getDisplayMedia
```

If `getDisplayMedia` rejects (user clicks Cancel → `NotAllowedError`, or browser denies):

- `updateLocalTracks` flips `screenshare.enabled` back to false.
- But the camera button is still off (we set it sync, before the await).
- The OLD camera track in `_localTracks.stream` is now disabled (loop on line 692-694 sets `track.enabled = video.enabled` which is `false`).
- User sees: both buttons off, no video, but camera light may still be on (track is `live` but disabled).

## Fix

Capture the camera's previous state. After `updateLocalTracks`, if the user wanted to *enable* screenshare and screenshare didn't take and the camera was on before, re-enable the camera button and call `updateLocalTracks({updateVideo: true})` once more so the camera track ends up enabled + live again.

## Test

New `static/tests/frontend-new/specs/screenshare.spec.ts`:
- Camera-on scenario: stub `getDisplayMedia` to throw `NotAllowedError` → click screenshare → assert camera button on, screenshare button off, **video track live + enabled**.
- Camera-off scenario: turn camera off, click screenshare, cancel → assert both buttons stay off (we don't auto-enable a camera the user explicitly turned off).

Couldn't run locally — my etherpad-lite checkout is on a feature branch whose `playwright.config.ts` doesn't auto-discover plugin specs. CI on develop has the right test-match config.

## Semver: patch

Bug fix.

## Test plan

- [ ] CI: new `screenshare.spec.ts` passes (2 cases) and existing suite stays green
- [ ] Manual smoke: pad with camera enabled → click screenshare button → click Cancel in picker → camera should still show live video, camera button should be on, screenshare button should be off

🤖 Generated with [Claude Code](https://claude.com/claude-code)