### PR TITLE
Adopt ep_plugin_helpers for eejs blocks and logger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,12 +37,18 @@ ep_webrtc/
 
 ## Helpers used
 
-_None — `ep_plugin_helpers` is not a dependency. Adoption is part of the helpers-adoption sweep (Phase 4)._
+`ep_plugin_helpers` is a dependency. Adopted in the helpers-adoption sweep:
+
+- **`template()`** — `eejsBlock_mySettings` and `eejsBlock_styles` render their templates via the factory (plugin-qualified paths, e.g. `ep_webrtc/templates/settings.ejs`) instead of hand-rolled `eejs.require(...)`.
+- **`logger()`** — the pre-init fallback logger is a named log4js logger (`logger('ep_webrtc')`), later replaced by the per-plugin logger core supplies in `init_ep_webrtc`.
 
 
 ## Helpers NOT used
 
-_To be audited in the helpers-adoption sweep (Phase 4)._
+The plugin-specific server logic stays hand-rolled because the generic helpers don't fit:
+
+- **`settings()`** — `clientVars` does per-pad ICE-server sharding (HMAC) plus ephemeral TURN credential fetching (coturn / xirsys), and `loadSettings` does a custom `_.mergeWith` array-replace + `disabled` validation. The generic relay only passes settings through verbatim.
+- **`messageRelay()`** — `handleMessage` / `handleRTCMessage` route signalling messages P2P (broadcast vs. targeted unicast to a specific author) and meter STATS errors; the generic relay can't express that.
 
 
 ## Running tests locally

--- a/index.js
+++ b/index.js
@@ -17,15 +17,13 @@
 const _ = require('lodash');
 const {Buffer} = require('buffer');
 const crypto = require('crypto');
-const eejs = require('ep_etherpad-lite/node/eejs/');
+const {template, logger: createLogger} = require('ep_plugin_helpers');
 const sessioninfos = require('ep_etherpad-lite/node/handler/PadMessageHandler').sessioninfos;
 const stats = require('ep_etherpad-lite/node/stats');
 const util = require('util');
 
-let logger = {};
-for (const level of ['debug', 'info', 'warn', 'error']) {
-  logger[level] = console[level].bind(console, 'ep_webrtc:');
-}
+// Overwritten with the per-plugin logger supplied by core in init_ep_webrtc.
+let logger = createLogger('ep_webrtc');
 
 const defaultSettings = {
   // The defaults here are overridden by the values in the `ep_webrtc` object from `settings.json`.
@@ -258,16 +256,14 @@ exports.init_ep_webrtc = async (hookName, {logger: l}) => {
 
 exports.setSocketIO = (hookName, {io}) => { socketio = io; };
 
-exports.eejsBlock_mySettings = (hookName, context) => {
-  context.content += eejs.require('./templates/settings.ejs', {
+exports.eejsBlock_mySettings = template('ep_webrtc/templates/settings.ejs', {
+  vars: () => ({
     audio_hard_disabled: settings.audio.disabled === 'hard',
     video_hard_disabled: settings.video.disabled === 'hard',
-  }, module);
-};
+  }),
+});
 
-exports.eejsBlock_styles = (hookName, context) => {
-  context.content += eejs.require('./templates/styles.html', {}, module);
-};
+exports.eejsBlock_styles = template('ep_webrtc/templates/styles.html');
 
 exports.loadSettings = async (hookName, {settings: {ep_webrtc: s = {}}}) => {
   settings = _.mergeWith({}, defaultSettings, s, (objV, srcV, key, obj, src) => {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "abort-controller": "^3.0.0",
+    "ep_plugin_helpers": "^0.6.3",
     "lodash": "^4.18.1",
     "node-fetch": "^3.3.2"
   },


### PR DESCRIPTION
Closes #281.

## What
Transition the boilerplate in `ep_webrtc` that cleanly fits the shared [`ep_plugin_helpers`](https://github.com/ether/ep_plugin_helpers) library:

- **`eejsBlock_mySettings` / `eejsBlock_styles`** → the `template()` factory instead of hand-rolled `eejs.require(...)` calls. This drops the direct `ep_etherpad-lite/node/eejs` import. Uses the plugin-qualified path form (`ep_webrtc/templates/...`) because the helper renders relative to its own module — same pattern as `ep_table_of_contents`.
- **Pre-init logger** → `logger('ep_webrtc')` (a real named log4js logger) instead of a hand-bound `console` shim. It is still overwritten by the per-plugin logger core supplies in `init_ep_webrtc`.
- Add `ep_plugin_helpers` as a dependency.

## What deliberately stayed custom
The meaty, plugin-specific parts don't fit the generic helpers and are left untouched:
- `clientVars` — per-pad ICE-server sharding (HMAC) + ephemeral TURN credential fetching (coturn / xirsys).
- `handleMessage` / `handleRTCMessage` — P2P routing (broadcast vs. targeted unicast) + the STATS error-meter branch.
- `loadSettings` — custom `_.mergeWith` array-replace + `disabled` validation.

## Verification
Ran against a local Etherpad with the branch symlinked in:
- Existing `sharding.js` backend suite — **7 passing**.
- Added an ad-hoc spec exercising both `eejsBlock_*` hooks — both render their templates correctly via the new path form (stylesheet link + settings checkboxes present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)