### PR TITLE
Update the self-view name/colour when you change it in the userlist

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -507,6 +507,17 @@ exports.rtc = new class {
     });
     $(window).on('beforeunload', () => { this.hangupAll(); });
     $(window).on('unload', () => { this.hangupAll(); });
+    // Core fires userJoinOrUpdate only for *remote* users, so editing your own
+    // name (or colour) in the userlist never reaches the self-view tile. Watch
+    // the userlist's own name field and colour swatch and re-sync the local
+    // tile. Delegated so it survives the userlist re-rendering its controls;
+    // deferred a tick so it runs after core's notifyChangeName/renderMyUserInfo
+    // has updated pad.myUserInfo.
+    const refreshSelfView =
+        () => setTimeout(() => this.updatePeerNameAndColor(this.getUserFromId(this.getUserId())), 0);
+    $(document).on(
+        'change.ep_webrtc blur.ep_webrtc', '#myusernameedit', refreshSelfView);
+    $(document).on('click.ep_webrtc', '#mycolorpickersave', refreshSelfView);
     // Skip auto-activation when the host has no audio/video device the
     // browser can see. Bisecting against ether/ep_webrtc CI proved that
     // the OUTER pad's activate() chain — specifically when getUserMedia
@@ -823,6 +834,19 @@ exports.rtc = new class {
 
   getUserFromId(userId) {
     if (!this._pad || !this._pad.collabClient) return null;
+    // The local user is not part of collabClient's connected-users set, so
+    // resolve their own name/colour from the pad's author fields. Without this
+    // the self-view shows "unnamed" even when the user has a name, and it never
+    // reflects a name change the user makes in the userlist (core does not fire
+    // the userJoinOrUpdate hook for the local user — see postAceInit).
+    if (userId === this.getUserId()) {
+      const myInfo = this._pad.myUserInfo || {};
+      return {
+        userId,
+        name: (this._pad.getUserName && this._pad.getUserName()) || myInfo.name,
+        colorId: myInfo.colorId != null ? myInfo.colorId : clientVars.userColor,
+      };
+    }
     const result = this._pad.collabClient
         .getConnectedUsers()
         .filter((user) => user.userId === userId);


### PR DESCRIPTION
Closes #286.

## Problem
Changing your own name in the userlist didn't update your own video tile in ep_webrtc. Remote peers saw the change (it rides the normal `USER_NEWINFO` broadcast → their `userJoinOrUpdate`), but your **own** self-view kept whatever it showed when the call started — and it showed **"unnamed"** even when you had a name set.

Two root causes:
1. Core fires the `userJoinOrUpdate` client hook **only for remote users** — `pad_userlist.ts` returns early when `info.userId === myUserInfo.userId`. So ep_webrtc never gets a signal for the local user's own name/colour change.
2. `getUserFromId()` only looked in `collabClient.getConnectedUsers()`, which never contains the local user → the self-view had no name source → "unnamed".

## Fix (plugin-only, works on all core versions)
- `getUserFromId()` resolves the **local** user from the pad's own author fields (`pad.getUserName()` / `pad.myUserInfo.colorId` / `clientVars.userColor`), so the self-view shows the real name & colour at activation.
- Watch the userlist's own name field (`#myusernameedit`) and the colour-picker save (`#mycolorpickersave`) and re-sync the self-view tile (deferred a tick so `pad.myUserInfo` is already updated; delegated so it survives userlist re-renders).

## Verification
Tested against a local Etherpad (core `develop`):
- Rename in the userlist → self-view label updates — in **both live and history/timeslider** views.
- A name set **before** the call starts is shown at activation (no longer "unnamed").

🤖 Generated with [Claude Code](https://claude.com/claude-code)